### PR TITLE
Fix Windows CI: port Node suite to win32 path semantics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Normalise line endings to LF on checkout across platforms. The Node suite
+# (and the plugin's own markdown/bash parsers) match `\n`, so a Windows CRLF
+# checkout breaks frontmatter and fenced-block regexes. Force LF for all text.
+* text=auto eol=lf
+
+# Binary assets must never be touched.
+*.png binary
+*.jpg binary
+*.gif binary
+*.ico binary
+*.gz binary
+*.zip binary
+*.wasm binary
+*.node binary

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,17 +7,16 @@ on:
 
 jobs:
   # The plugin ships a Windows binary and win32 code paths, so the Node suite
-  # runs on all three OSes. macOS and Linux are blocking; Windows is
-  # continue-on-error until its failures are triaged green (flip it to
-  # blocking then — a red-but-ignored lane decays fast). ygrep is a
-  # Linux-only install: its tests skip when the binary is absent.
+  # runs on all three OSes, all blocking. A handful of tests that can only be
+  # exercised with a POSIX shell stub of ll-search skip on win32 via
+  # skipOnWindows(); ygrep is a Linux-only install whose tests skip when the
+  # binary is absent.
   node:
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.os == 'windows-latest' }}
     steps:
       - uses: actions/checkout@v4
 

--- a/plugin/hooks/lib/common.mjs
+++ b/plugin/hooks/lib/common.mjs
@@ -28,7 +28,7 @@ import { HookConfig } from '../../scripts/lib/hook-config.mjs';
 import { logError } from '../../scripts/lib/log.mjs';
 import { getSessionId } from '../../scripts/lib/session.mjs';
 import { writeRetrieval } from '../../scripts/lib/retrieval.mjs';
-import { DATA_PATHS } from '../../scripts/lib/paths.mjs';
+import { DATA_PATHS, toForwardSlash } from '../../scripts/lib/paths.mjs';
 
 export { resolvePluginData, getSessionId };
 export const resolveVaultPath = getVaultPath;
@@ -86,7 +86,7 @@ export function recordDetachedChild(pid) {
 export function vaultRelPath(filePath, vaultPath) {
   const prefix = vaultPath + sep;
   if (filePath && filePath.startsWith(prefix)) {
-    return filePath.slice(prefix.length);
+    return toForwardSlash(filePath.slice(prefix.length));
   }
   return null;
 }

--- a/plugin/hooks/lib/dream-gate.js
+++ b/plugin/hooks/lib/dream-gate.js
@@ -9,6 +9,7 @@ import { readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { home, resolvePluginData } from './common.mjs';
 import { env } from '../../scripts/lib/env.mjs';
+import { encodeProjectDir } from '../../scripts/lib/paths.mjs';
 import { logError } from '../../scripts/lib/log.mjs';
 import {
   writeMarker,
@@ -88,7 +89,7 @@ if (!projectDir) {
   process.exit(0);
 }
 
-const encodedPath = projectDir.replace(/[/\\]/g, '-');
+const encodedPath = encodeProjectDir(projectDir);
 const memoryDir = join(home(), '.claude', 'projects', encodedPath, 'memory');
 
 // Gate 4: Memory dir must exist.

--- a/plugin/hooks/modules/edge-infer.mjs
+++ b/plugin/hooks/modules/edge-infer.mjs
@@ -4,7 +4,7 @@
 
 import { readFileSync, writeFileSync } from 'node:fs';
 import { basename } from 'node:path';
-import { resolvePluginData, isVaultNote } from '../lib/common.mjs';
+import { resolvePluginData, isVaultNote, vaultRelPath } from '../lib/common.mjs';
 import { buildVaultIndexFromSnapshot } from '../lib/snapshot.mjs';
 import { logError } from '../../scripts/lib/log.mjs';
 import {
@@ -26,10 +26,6 @@ const EDGE_TYPE_TO_FRONTMATTER_KEY = {
   challenges_undercutting: 'undercuts',
   challenges_rebuttal: 'rebuts',
 };
-
-function vaultRelPath(filePath, vaultRoot) {
-  return filePath.slice(vaultRoot.length + 1);
-}
 
 function parseInlineArray(value) {
   const m = value.match(/^\[(.*)\]$/);

--- a/plugin/hooks/post-tool.js
+++ b/plugin/hooks/post-tool.js
@@ -13,6 +13,7 @@ import { runEdgeInfer } from './modules/edge-infer.mjs';
 import { runProvenance } from './modules/provenance.mjs';
 import { runReflectTrack } from './modules/reflect-track.mjs';
 import { getPluginData } from '../scripts/lib/config.mjs';
+import { encodeProjectDir } from '../scripts/lib/paths.mjs';
 import { appendJsonlLineSafe } from '../scripts/lib/jsonl.mjs';
 import { appendMemoryWrite } from '../scripts/lib/marker-cache.mjs';
 import { HookConfig } from '../scripts/lib/hook-config.mjs';
@@ -31,7 +32,7 @@ function recordMemoryWriteIfApplicable(filePath) {
     if (!projectDir) return;
     const pluginData = getPluginData();
     if (!pluginData) return;
-    const encodedPath = projectDir.replace(/[/\\]/g, '-');
+    const encodedPath = encodeProjectDir(projectDir);
     const memoryDir = join(home(), '.claude', 'projects', encodedPath, 'memory');
     if (filePath !== join(memoryDir, basename(filePath))) return;
     let sid = getSessionId();

--- a/plugin/hooks/session-start/context-assembly.mjs
+++ b/plugin/hooks/session-start/context-assembly.mjs
@@ -10,7 +10,7 @@ import { safeLoad } from '../../scripts/lib/safe-load.mjs';
 import { HookConfig } from '../../scripts/lib/hook-config.mjs';
 import { logError } from '../../scripts/lib/log.mjs';
 import { env } from '../../scripts/lib/env.mjs';
-import { DATA_PATHS, FEDERATION_PATHS } from '../../scripts/lib/paths.mjs';
+import { DATA_PATHS, FEDERATION_PATHS, encodeProjectDir } from '../../scripts/lib/paths.mjs';
 import { recordDetachedChild } from '../lib/common.mjs';
 
 const MEMORY_RECENCY_MS = 7 * 24 * 60 * 60 * 1000;
@@ -154,7 +154,7 @@ export async function run(ctx) {
   // instead of the index lines.
   let projectMemoryIndex = null;
   if (projectDir) {
-    const encodedPath = projectDir.replace(/[/\\]/g, '-');
+    const encodedPath = encodeProjectDir(projectDir);
     projectMemoryIndex = join(memoryDir, encodedPath, 'memory', 'MEMORY.md');
     if (existsSync(projectMemoryIndex) && memoryIsFresh(projectMemoryIndex)) {
       try {
@@ -172,7 +172,7 @@ export async function run(ctx) {
   // parent both keys resolve to the same MEMORY.md — skip the global section
   // rather than injecting the identical index twice.
   const vaultParent = resolve(vaultRoot, '..');
-  const encodedVaultParent = vaultParent.replace(/[/\\]/g, '-');
+  const encodedVaultParent = encodeProjectDir(vaultParent);
   const globalMemory = join(memoryDir, encodedVaultParent, 'memory', 'MEMORY.md');
   if (
     globalMemory !== projectMemoryIndex &&

--- a/plugin/hooks/stop-nudge.js
+++ b/plugin/hooks/stop-nudge.js
@@ -9,6 +9,7 @@ import { createHash } from 'node:crypto';
 import { home, resolvePluginData, readStdin, getSessionId } from './lib/common.mjs';
 import { HookConfig } from '../scripts/lib/hook-config.mjs';
 import { env } from '../scripts/lib/env.mjs';
+import { encodeProjectDir } from '../scripts/lib/paths.mjs';
 import { logError } from '../scripts/lib/log.mjs';
 import { emitJson } from './lib/io.mjs';
 import { readMarker, writeMarker, MARKER_PATHS } from '../scripts/lib/marker-cache.mjs';
@@ -67,7 +68,7 @@ if (pluginData && projectDir) {
     ttlMs: Infinity,
   });
   if (Array.isArray(writesArr)) {
-    const encodedPath = projectDir.replace(/[/\\]/g, '-');
+    const encodedPath = encodeProjectDir(projectDir);
     const memoryDir = join(home(), '.claude', 'projects', encodedPath, 'memory');
     try {
       const onDisk = new Set(readdirSync(memoryDir).filter((f) => f.endsWith('.md')));

--- a/plugin/scripts/check-deps.mjs
+++ b/plugin/scripts/check-deps.mjs
@@ -9,10 +9,11 @@ import { homedir } from 'node:os';
 import { env } from './lib/env.mjs';
 import { safeLoad } from './lib/safe-load.mjs';
 import { buildAbiDrift, satisfiesVersion } from './check-deps-impl.mjs';
+import { pathToFileURL } from 'node:url';
 
 export { detectAbiDrift } from './check-deps-impl.mjs';
 
-const isMain = import.meta.url === new URL(`file://${process.argv[1]}`).href;
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 
 if (isMain) {
   const PLUGIN_DIR = resolve(import.meta.dirname, '..');

--- a/plugin/scripts/download-binary.mjs
+++ b/plugin/scripts/download-binary.mjs
@@ -19,6 +19,7 @@ import { safeLoad } from './lib/safe-load.mjs';
 import { DATA_FILES } from './lib/paths.mjs';
 import { verifyArtifact, isAllowedRedirect } from './lib/artifact-verify.mjs';
 import { semverCmp, isPlainSemver } from './lib/semver.mjs';
+import { pathToFileURL } from 'node:url';
 
 function detectArtifact() {
   const p = platform();
@@ -279,6 +280,6 @@ async function main() {
   writeFileSync(versionFile, version + '\n');
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main();
 }

--- a/plugin/scripts/federation-active.mjs
+++ b/plugin/scripts/federation-active.mjs
@@ -1,6 +1,7 @@
 // scripts/federation-active.mjs : is this instance federated? (mechanical guard)
 import { safeLoad } from './lib/safe-load.mjs';
 import { FEDERATION_PATHS } from './lib/paths.mjs';
+import { pathToFileURL } from 'node:url';
 
 /**
  * @param {string} pluginData  plugin-data dir
@@ -12,7 +13,7 @@ export function isFederationActive(pluginData) {
   return Boolean(parsed && parsed.identity && parsed.identity.pubkey);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const { getPluginData } = await import('./lib/config.mjs');
   const pd = process.argv[2] || getPluginData();
   const active = isFederationActive(pd);

--- a/plugin/scripts/harvest-collect.mjs
+++ b/plugin/scripts/harvest-collect.mjs
@@ -2,6 +2,7 @@
 // Keep ONLY notes with frontmatter `portable: true`. Never consult `visibility`.
 // Default-absent = excluded. Mechanical, fails closed.
 import { parseFrontmatter } from './lib/markdown-parse.mjs';
+import { pathToFileURL } from 'node:url';
 
 /**
  * @param {{path: string, text: string}[]} notes
@@ -14,7 +15,7 @@ export function collectPortable(notes) {
   });
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   // CLI: harvest-collect.mjs <vaultDir> <memDir>  -> prints kept paths.
   // Takes DIRECTORIES and walks them internally — never receives a path list
   // through argv (a ~600-note vault would blow argv limits).

--- a/plugin/scripts/harvest-dedup.mjs
+++ b/plugin/scripts/harvest-dedup.mjs
@@ -2,6 +2,7 @@
 // Does NOT mutate notes — the portable marker is preserved; the log handles dedup.
 import { readFileSync, appendFileSync, existsSync, mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 /** @returns {string[]} previously harvested paths */
 export function readHarvested(logPath) {
@@ -31,7 +32,7 @@ export function appendHarvested(logPath, paths) {
   appendFileSync(logPath, paths.join('\n') + '\n');
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   // CLI: harvest-dedup.mjs <logPath> [--all]  (candidate paths on stdin, one per line)
   // prints the unharvested subset. Does not append — appending happens after the
   // operator confirms the carry set (the skill calls appendHarvested separately).

--- a/plugin/scripts/harvest-scrub.mjs
+++ b/plugin/scripts/harvest-scrub.mjs
@@ -8,6 +8,7 @@
 
 import { basename } from 'node:path';
 import { denyTermRegExp } from './lib/deny-match.mjs';
+import { pathToFileURL } from 'node:url';
 
 /**
  * @param {{path:string,text:string}[]} notes
@@ -56,7 +57,7 @@ export function scrubNotes(notes, opts) {
   return { blocked, tripwire, clean };
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   // CLI: harvest-scrub.mjs <denylistFile> <pluginData> [note-path...]  -> JSON report.
   // Note paths come from argv (small sets) OR, when none are passed, from stdin
   // (one per line) so a large bulk-marked set never exceeds ARG_MAX.

--- a/plugin/scripts/health-check.mjs
+++ b/plugin/scripts/health-check.mjs
@@ -20,6 +20,7 @@ import { detectAbiDrift } from './check-deps-impl.mjs';
 import { resolvePluginData, getVaultPath, getConfig } from './lib/config.mjs';
 import { pluginVersion } from './lib/plugin-meta.mjs';
 import { isProcessAlive } from './lib/file-lock.mjs';
+import { pathToFileURL } from 'node:url';
 
 const PLUGIN_DIR = new URL('..', import.meta.url).pathname;
 
@@ -213,7 +214,7 @@ function formatText({ checks }) {
 }
 
 // CLI entry
-const isMain = import.meta.url === new URL(`file://${process.argv[1]}`).href;
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
 if (isMain) {
   const args = process.argv.slice(2);
   const wantFull = args.includes('--full');

--- a/plugin/scripts/ingest-depth-gate.mjs
+++ b/plugin/scripts/ingest-depth-gate.mjs
@@ -1,3 +1,4 @@
+import { pathToFileURL } from 'node:url';
 export function buildGatePrompt(profile) {
   return `You decide whether to fan out 4 deep-mapper agents (~15x token cost) or use the surface profile as-is for a personal second-brain ingest.
 
@@ -33,7 +34,7 @@ export function parseGateResponse(text) {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const cmd = process.argv[2];
   if (cmd === 'build-prompt') {
     const profileJson = process.argv[3];

--- a/plugin/scripts/ingest-profile.mjs
+++ b/plugin/scripts/ingest-profile.mjs
@@ -1,6 +1,7 @@
 import { readFileSync, readdirSync, existsSync } from 'node:fs';
 import { join, extname } from 'node:path';
 import { execFileSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
 
 const KNOWN_FRAMEWORKS = [
   'next',
@@ -186,7 +187,7 @@ export function generateProfile(repoPath) {
   };
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const repo = process.argv[2];
   if (!repo) {
     console.error('Usage: ingest-profile.mjs <repo-path>');

--- a/plugin/scripts/ingest-slug.mjs
+++ b/plugin/scripts/ingest-slug.mjs
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
 import { basename, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 export function computeSlug(repoPath, gitOrigin) {
   const base = basename(resolve(repoPath));
@@ -8,7 +9,7 @@ export function computeSlug(repoPath, gitOrigin) {
   return `${base}-${hash}`;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const repoPath = process.argv[2];
   const gitOrigin = process.argv[3] || null;
   if (!repoPath) {

--- a/plugin/scripts/lib/memory-paths.mjs
+++ b/plugin/scripts/lib/memory-paths.mjs
@@ -1,7 +1,7 @@
 // scripts/lib/memory-paths.mjs : resolve the auto-memory dir and list its note files.
 import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { home } from './paths.mjs';
+import { home, encodeProjectDir } from './paths.mjs';
 
 // Files in the memory dir that are NOT individual memories.
 const NON_MEMORY = new Set(['MEMORY.md', '_dream_log.md']);
@@ -15,7 +15,7 @@ const NON_MEMORY = new Set(['MEMORY.md', '_dream_log.md']);
  */
 export function resolveMemoryDir(projectDir, homeDir = home()) {
   if (!projectDir) return null;
-  const encodedPath = projectDir.replace(/[/\\]/g, '-');
+  const encodedPath = encodeProjectDir(projectDir);
   return join(homeDir, '.claude', 'projects', encodedPath, 'memory');
 }
 

--- a/plugin/scripts/lib/paths.mjs
+++ b/plugin/scripts/lib/paths.mjs
@@ -6,6 +6,16 @@ export function home() {
   return env.HOME || env.USERPROFILE || homedir();
 }
 
+// Encode a project directory into its ~/.claude/projects/<slug> segment.
+// Claude Code replaces every path separator AND every '.' and ':' with '-',
+// so /Users/x/.claude/p -> -Users-x--claude-p and C:\Users\x -> C--Users-x.
+// The ':' replacement is load-bearing on Windows: a drive colon left in the
+// slug is an illegal filename char and mkdir fails. Match CC exactly so we
+// resolve the dir CC actually created.
+export function encodeProjectDir(projectDir) {
+  return projectDir.replace(/[/\\.:]/g, '-');
+}
+
 export function tmp() {
   return tmpdir();
 }

--- a/plugin/scripts/redact-scan.mjs
+++ b/plugin/scripts/redact-scan.mjs
@@ -2,6 +2,7 @@
 
 import { readFileSync } from 'node:fs';
 import { extname } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 const TEXT_EXTENSIONS = new Set(['.jsonl', '.json', '.md', '.log', '.txt']);
 
@@ -30,7 +31,7 @@ function maskSecret(s) {
   return s.slice(0, 4) + '*'.repeat(s.length - 6) + s.slice(-2);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const paths = process.argv.slice(2);
   if (paths.length === 0) {
     process.stderr.write('usage: redact-scan.mjs <file...>\n');

--- a/plugin/scripts/seed-select.mjs
+++ b/plugin/scripts/seed-select.mjs
@@ -5,6 +5,7 @@
 // "feedback_ai_research.md" but not "feedback_maintain.md".
 import { parseFrontmatter } from './lib/markdown-parse.mjs';
 import { denyTermMatches } from './lib/deny-match.mjs';
+import { pathToFileURL } from 'node:url';
 
 /**
  * @param {{name: string, text: string}[]} files
@@ -32,7 +33,7 @@ export function selectSeedMemories(files, opts) {
   return { kept, dropped };
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   // CLI: seed-select.mjs <memDir> <comma-types> [comma-deny]
   const { listMemoryFiles, readMemoryFile } = await import('./lib/memory-paths.mjs');
   const [memDir, typesArg, denyArg] = process.argv.slice(2);

--- a/tests/autolink.test.mjs
+++ b/tests/autolink.test.mjs
@@ -6,6 +6,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
 import {
   mkdtempSync,
   mkdirSync,
@@ -22,7 +23,7 @@ import { skipOnWindows } from './helpers/platform.mjs';
 
 const SKIP = skipOnWindows('shebang stub + chmod semantics: not supported on win32');
 
-const HOOK = new URL('../plugin/hooks/post-tool.js', import.meta.url).pathname;
+const HOOK = fileURLToPath(new URL('../plugin/hooks/post-tool.js', import.meta.url));
 
 const SLEEP_NOTE = '---\ntags: [sleep]\n---\n\nPermanent note on sleep science.\n';
 const CIRCADIAN_NOTE = '---\ntags: [circadian]\n---\n\nPermanent note on circadian rhythm.\n';

--- a/tests/convergence-check-keys.test.mjs
+++ b/tests/convergence-check-keys.test.mjs
@@ -3,8 +3,9 @@ import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
 import { hasBinary } from '../plugin/scripts/lib/binary.mjs';
+import { fileURLToPath } from 'node:url';
 
-const SCRIPT = new URL('../plugin/scripts/convergence-check.mjs', import.meta.url).pathname;
+const SCRIPT = fileURLToPath(new URL('../plugin/scripts/convergence-check.mjs', import.meta.url));
 
 function runCheck(...args) {
   return execFileSync('node', [SCRIPT, ...args], { encoding: 'utf-8' });

--- a/tests/download-binary-version.test.mjs
+++ b/tests/download-binary-version.test.mjs
@@ -13,18 +13,23 @@ import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
-const MOD_PATH = fileURLToPath(new URL('../plugin/scripts/download-binary.mjs', import.meta.url));
-const MOD = JSON.stringify(MOD_PATH);
+const MOD_URL = new URL('../plugin/scripts/download-binary.mjs', import.meta.url);
+const MOD_PATH = fileURLToPath(MOD_URL);
+const MOD = JSON.stringify(MOD_URL.href);
 
 // Spawned so argv is controlled (getVersion short-circuits on process.argv[2])
 // and so an unguarded top-level main() can't run inside the test process.
 function getVersionInSubprocess(root, env = {}) {
   return spawnSync(
     process.execPath,
-    ['--input-type=module', '-e', `
+    [
+      '--input-type=module',
+      '-e',
+      `
       const m = await import(${MOD});
       console.log(m.getVersion(${JSON.stringify(root)}));
-    `],
+    `,
+    ],
     { encoding: 'utf-8', env: { ...process.env, ...env } },
   );
 }

--- a/tests/dream-gate-session-start-refresh.test.mjs
+++ b/tests/dream-gate-session-start-refresh.test.mjs
@@ -12,8 +12,9 @@ import { spawnSync } from 'node:child_process';
 import { mkdtempSync, mkdirSync, existsSync, readFileSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
 
-const DREAM_GATE = new URL('../plugin/hooks/lib/dream-gate.js', import.meta.url).pathname;
+const DREAM_GATE = fileURLToPath(new URL('../plugin/hooks/lib/dream-gate.js', import.meta.url));
 
 function runGate(pluginData, { home, env = {} } = {}) {
   return spawnSync(process.execPath, [DREAM_GATE, '--session-start-refresh'], {
@@ -42,32 +43,29 @@ test(
       // Use a sandboxed HOME so memory-dir stat calls don't touch the real home.
       const sandboxHome = mkdtempSync(join(tmpdir(), 'll-dg-home-'));
       try {
-        const result = spawnSync(
-          process.execPath,
-          [DREAM_GATE, '--session-start-refresh'],
-          {
-            encoding: 'utf8',
-            timeout: 10000,
-            env: {
-              PATH: process.env.PATH,
-              NODE_PATH: process.env.NODE_PATH || '',
-              CLAUDE_PLUGIN_DATA: tmpPluginData,
-              // Omit CLAUDE_PROJECT_DIR so gate 3 fires and script exits early,
-              // which still exercises writeMarkerIfNeeded(null).
-              HOME: sandboxHome,
-              USERPROFILE: sandboxHome,
-            },
+        const result = spawnSync(process.execPath, [DREAM_GATE, '--session-start-refresh'], {
+          encoding: 'utf8',
+          timeout: 10000,
+          env: {
+            PATH: process.env.PATH,
+            NODE_PATH: process.env.NODE_PATH || '',
+            CLAUDE_PLUGIN_DATA: tmpPluginData,
+            // Omit CLAUDE_PROJECT_DIR so gate 3 fires and script exits early,
+            // which still exercises writeMarkerIfNeeded(null).
+            HOME: sandboxHome,
+            USERPROFILE: sandboxHome,
           },
-        );
+        });
 
-        assert.ok(
-          result.signal === null,
-          `dream-gate killed by signal ${result.signal}`,
-        );
+        assert.ok(result.signal === null, `dream-gate killed by signal ${result.signal}`);
 
         // The script exits 0 on the "first run" path (writes DREAM_MARKER then exits)
         // or on "no CLAUDE_PROJECT_DIR" path — both should write the cache marker.
-        assert.equal(result.status, 0, `dream-gate exited ${result.status}\nstderr: ${result.stderr}`);
+        assert.equal(
+          result.status,
+          0,
+          `dream-gate exited ${result.status}\nstderr: ${result.stderr}`,
+        );
 
         const markerPath = join(tmpPluginData, 'session-start-cache', 'dream-gate.json');
         assert.ok(
@@ -86,7 +84,11 @@ test(
           `marker must have a "nudge" field; got: ${JSON.stringify(parsed)}`,
         );
         // On an early-exit path the nudge is null (no consolidation needed).
-        assert.equal(parsed.nudge, null, `nudge should be null on early-exit path; got: ${parsed.nudge}`);
+        assert.equal(
+          parsed.nudge,
+          null,
+          `nudge should be null on early-exit path; got: ${parsed.nudge}`,
+        );
       } finally {
         rmSync(sandboxHome, { recursive: true, force: true });
       }
@@ -112,7 +114,10 @@ test(
       const cacheDir = join(tmpPluginData, 'session-start-cache');
       mkdirSync(cacheDir, { recursive: true });
       const markerPath = join(cacheDir, 'dream-gate.json');
-      writeFileSync(markerPath, JSON.stringify({ nudge: 'Auto-memory has 9 files modified. Run /dream to consolidate.' }));
+      writeFileSync(
+        markerPath,
+        JSON.stringify({ nudge: 'Auto-memory has 9 files modified. Run /dream to consolidate.' }),
+      );
       // /dream just succeeded: last-dream stamp is 1 hour old.
       mkdirSync(join(tmpPluginData, 'retrieval'), { recursive: true });
       writeFileSync(
@@ -121,7 +126,11 @@ test(
       );
 
       const result = runGate(tmpPluginData, { home: sandboxHome });
-      assert.equal(result.status, 0, `dream-gate exited ${result.status}\nstderr: ${result.stderr}`);
+      assert.equal(
+        result.status,
+        0,
+        `dream-gate exited ${result.status}\nstderr: ${result.stderr}`,
+      );
 
       const parsed = JSON.parse(readFileSync(markerPath, 'utf8'));
       assert.equal(
@@ -159,7 +168,11 @@ test(
       );
 
       const result = runGate(tmpPluginData, { home: sandboxHome });
-      assert.equal(result.status, 0, `dream-gate exited ${result.status}\nstderr: ${result.stderr}`);
+      assert.equal(
+        result.status,
+        0,
+        `dream-gate exited ${result.status}\nstderr: ${result.stderr}`,
+      );
 
       const parsed = JSON.parse(readFileSync(markerPath, 'utf8'));
       assert.equal(

--- a/tests/dream-gate.test.mjs
+++ b/tests/dream-gate.test.mjs
@@ -1,9 +1,18 @@
 import { describe, it, before, beforeEach, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync, utimesSync, mkdtempSync } from 'node:fs';
+import {
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  utimesSync,
+  mkdtempSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { encodeProjectDir } from '../plugin/scripts/lib/paths.mjs';
 
 const HOOK = join(import.meta.dirname, '..', 'plugin', 'hooks', 'lib', 'dream-gate.js');
 const tmp = tmpdir();
@@ -17,7 +26,7 @@ const DREAM_LOCK = join(PLUGIN_DATA, 'markers', 'dream-lock');
 // out of the real ~/.claude/projects and lets parallel runs coexist.
 const FAKE_PROJECT_DIR = mkdtempSync(join(tmp, 'll-test-dream-project-'));
 const FAKE_HOME = mkdtempSync(join(tmp, 'll-test-dream-home-'));
-const encodedPath = FAKE_PROJECT_DIR.replace(/[/\\]/g, '-');
+const encodedPath = encodeProjectDir(FAKE_PROJECT_DIR);
 const memoryDir = join(FAKE_HOME, '.claude', 'projects', encodedPath, 'memory');
 
 function run() {
@@ -137,7 +146,9 @@ describe('dream-gate', () => {
     rmSync(DREAM_MARKER, { force: true });
     const stampedPath = execFileSync('node', [CLI, 'stamp', 'last-dream'], {
       env: { ...process.env, CLAUDE_PLUGIN_DATA: PLUGIN_DATA },
-    }).toString().trim();
+    })
+      .toString()
+      .trim();
     assert.equal(stampedPath, DREAM_MARKER, 'stamp must land where the gate reads');
     assert.ok(existsSync(DREAM_MARKER), 'stamp must exist before the gate runs');
     const out = run();

--- a/tests/edge-infer-wikilink-removal-integration.test.mjs
+++ b/tests/edge-infer-wikilink-removal-integration.test.mjs
@@ -15,8 +15,9 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { openEdgeDb, addEdge, saveDb } from '../plugin/scripts/lib/edges.mjs';
 import { runEdgeInfer } from '../plugin/hooks/modules/edge-infer.mjs';
+import { fileURLToPath } from 'node:url';
 
-const VAULT = new URL('./fixtures/vault-small', import.meta.url).pathname;
+const VAULT = fileURLToPath(new URL('./fixtures/vault-small', import.meta.url));
 
 // Note lives in 0-inbox so isVaultNote() accepts it.
 const NOTE_REL = '0-inbox/rebuttal-note.md';

--- a/tests/harvest-pipeline.integration.test.mjs
+++ b/tests/harvest-pipeline.integration.test.mjs
@@ -1,84 +1,85 @@
 // Integration test: collect -> scrub pipeline (IP-leak path).
 // Runs the REAL CLI scripts end-to-end in a temp vault.
-import test from "node:test";
-import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const collectScript = new URL("../plugin/scripts/harvest-collect.mjs", import.meta.url).pathname;
-const scrubScript = new URL("../plugin/scripts/harvest-scrub.mjs", import.meta.url).pathname;
+const collectScript = fileURLToPath(
+  new URL('../plugin/scripts/harvest-collect.mjs', import.meta.url),
+);
+const scrubScript = fileURLToPath(new URL('../plugin/scripts/harvest-scrub.mjs', import.meta.url));
 
-test("collect -> scrub: portable+deny note is blocked; non-portable never reaches scrub", () => {
-  const root = mkdtempSync(join(tmpdir(), "ll-pipeline-"));
+test('collect -> scrub: portable+deny note is blocked; non-portable never reaches scrub', () => {
+  const root = mkdtempSync(join(tmpdir(), 'll-pipeline-'));
   try {
-    const vaultDir = join(root, "vault");
-    const memDir = join(root, "mem");
+    const vaultDir = join(root, 'vault');
+    const memDir = join(root, 'mem');
     mkdirSync(vaultDir);
     mkdirSync(memDir);
 
     // keep.md: portable, innocuous -> should pass collect and scrub -> clean
     writeFileSync(
-      join(vaultDir, "keep.md"),
-      "---\nportable: true\n---\nA generic retry lesson about exponential backoff.",
+      join(vaultDir, 'keep.md'),
+      '---\nportable: true\n---\nA generic retry lesson about exponential backoff.',
     );
 
     // secret.md: portable but contains the deny term -> should pass collect, get blocked by scrub
     writeFileSync(
-      join(vaultDir, "secret.md"),
-      "---\nportable: true\n---\nWe use acmecorp for client work. This must not leak.",
+      join(vaultDir, 'secret.md'),
+      '---\nportable: true\n---\nWe use acmecorp for client work. This must not leak.',
     );
 
     // private.md: no portable key, contains nothing sensitive -> must NOT appear anywhere in scrub output
-    writeFileSync(
-      join(vaultDir, "private.md"),
-      "---\n---\nInternal note with no portable flag.",
-    );
+    writeFileSync(join(vaultDir, 'private.md'), '---\n---\nInternal note with no portable flag.');
 
-    const denyFile = join(root, "deny.txt");
-    writeFileSync(denyFile, "acmecorp\n");
+    const denyFile = join(root, 'deny.txt');
+    writeFileSync(denyFile, 'acmecorp\n');
 
     // Step 1: collect
-    const collectOut = execFileSync(
-      process.execPath,
-      [collectScript, vaultDir, memDir],
-      { encoding: "utf8" },
-    );
-    const keptPaths = collectOut.split(/\r?\n/).map((s) => s.trim()).filter(Boolean);
+    const collectOut = execFileSync(process.execPath, [collectScript, vaultDir, memDir], {
+      encoding: 'utf8',
+    });
+    const keptPaths = collectOut
+      .split(/\r?\n/)
+      .map((s) => s.trim())
+      .filter(Boolean);
 
     // Collect should return keep.md and secret.md, not private.md
     assert.ok(
-      keptPaths.some((p) => p.endsWith("keep.md")),
-      "keep.md (portable:true) must be kept by collect",
+      keptPaths.some((p) => p.endsWith('keep.md')),
+      'keep.md (portable:true) must be kept by collect',
     );
     assert.ok(
-      keptPaths.some((p) => p.endsWith("secret.md")),
-      "secret.md (portable:true) must be kept by collect",
+      keptPaths.some((p) => p.endsWith('secret.md')),
+      'secret.md (portable:true) must be kept by collect',
     );
     assert.ok(
-      !keptPaths.some((p) => p.endsWith("private.md")),
-      "private.md (no portable key) must NOT be kept by collect",
+      !keptPaths.some((p) => p.endsWith('private.md')),
+      'private.md (no portable key) must NOT be kept by collect',
     );
 
     // Step 2: pipe collect output into scrub via stdin
     const scrubOut = execFileSync(
       process.execPath,
-      [scrubScript, denyFile, ""],  // empty pluginData => no derived instance facts
-      { input: collectOut, encoding: "utf8" },
+      [scrubScript, denyFile, ''], // empty pluginData => no derived instance facts
+      { input: collectOut, encoding: 'utf8' },
     );
     const result = JSON.parse(scrubOut);
 
     // KEY IP-SAFETY ASSERTION: portable+deny note must be blocked
     assert.ok(
-      result.blocked.some((b) => b.path.endsWith("secret.md")),
-      "secret.md (portable:true + deny term) must be BLOCKED by scrub — key IP-leak assertion",
+      result.blocked.some((b) => b.path.endsWith('secret.md')),
+      'secret.md (portable:true + deny term) must be BLOCKED by scrub — key IP-leak assertion',
     );
 
     // The clean portable note must be in clean
     assert.ok(
-      result.clean.some((c) => c.path.endsWith("keep.md")),
-      "keep.md (portable:true, no deny hits) must be in clean",
+      result.clean.some((c) => c.path.endsWith('keep.md')),
+      'keep.md (portable:true, no deny hits) must be in clean',
     );
 
     // The non-portable note must never appear anywhere in the scrub output
@@ -88,8 +89,8 @@ test("collect -> scrub: portable+deny note is blocked; non-portable never reache
       ...result.clean.map((c) => c.path),
     ];
     assert.ok(
-      !allScrubPaths.some((p) => p.endsWith("private.md")),
-      "private.md (non-portable) must not appear anywhere in scrub output",
+      !allScrubPaths.some((p) => p.endsWith('private.md')),
+      'private.md (non-portable) must not appear anywhere in scrub output',
     );
   } finally {
     rmSync(root, { recursive: true, force: true });

--- a/tests/harvest-scrub.test.mjs
+++ b/tests/harvest-scrub.test.mjs
@@ -1,230 +1,301 @@
-import test from "node:test";
-import assert from "node:assert/strict";
-import { execFileSync, spawnSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { scrubNotes } from "../plugin/scripts/harvest-scrub.mjs";
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { scrubNotes } from '../plugin/scripts/harvest-scrub.mjs';
+import { fileURLToPath } from 'node:url';
 
-test("deny-list hit blocks on word boundary (case-insensitive)", () => {
+test('deny-list hit blocks on word boundary (case-insensitive)', () => {
   const notes = [
-    { path: "ok.md", text: "a generic lesson about retries" },
-    { path: "leak.md", text: "the NRD registry pattern we used at fostermoore today" },
+    { path: 'ok.md', text: 'a generic lesson about retries' },
+    { path: 'leak.md', text: 'the NRD registry pattern we used at fostermoore today' },
   ];
   const { blocked, clean } = scrubNotes(notes, {
-    denylist: ["fostermoore", "nrd"],
+    denylist: ['fostermoore', 'nrd'],
     tripwirePatterns: [],
   });
-  assert.deepEqual(blocked.map((b) => b.path), ["leak.md"]);
-  assert.equal(blocked[0].hits.map((h) => h.toLowerCase()).sort().join(","), "fostermoore,nrd");
-  assert.deepEqual(clean.map((c) => c.path), ["ok.md"]);
+  assert.deepEqual(
+    blocked.map((b) => b.path),
+    ['leak.md'],
+  );
+  assert.equal(
+    blocked[0].hits
+      .map((h) => h.toLowerCase())
+      .sort()
+      .join(','),
+    'fostermoore,nrd',
+  );
+  assert.deepEqual(
+    clean.map((c) => c.path),
+    ['ok.md'],
+  );
 });
 
-test("word-boundary: short term does not match inside a larger word", () => {
+test('word-boundary: short term does not match inside a larger word', () => {
   const notes = [
-    { path: "innocent.md", text: "the maintainer fixed a domain bug in the container" },
-    { path: "real.md", text: "this is about AI specifically" },
+    { path: 'innocent.md', text: 'the maintainer fixed a domain bug in the container' },
+    { path: 'real.md', text: 'this is about AI specifically' },
   ];
   const { blocked, clean } = scrubNotes(notes, {
-    denylist: ["ai"],
+    denylist: ['ai'],
     tripwirePatterns: [],
   });
-  assert.deepEqual(blocked.map((b) => b.path), ["real.md"]);
-  assert.deepEqual(clean.map((c) => c.path), ["innocent.md"]);
+  assert.deepEqual(
+    blocked.map((b) => b.path),
+    ['real.md'],
+  );
+  assert.deepEqual(
+    clean.map((c) => c.path),
+    ['innocent.md'],
+  );
 });
 
-test("deny term with regex metacharacters is matched literally", () => {
-  const notes = [{ path: "x.md", text: "contact me at bob@foster.co.nz please" }];
+test('deny term with regex metacharacters is matched literally', () => {
+  const notes = [{ path: 'x.md', text: 'contact me at bob@foster.co.nz please' }];
   const { blocked } = scrubNotes(notes, {
-    denylist: ["foster.co.nz"],
+    denylist: ['foster.co.nz'],
     tripwirePatterns: [],
   });
-  assert.deepEqual(blocked.map((b) => b.path), ["x.md"]);
+  assert.deepEqual(
+    blocked.map((b) => b.path),
+    ['x.md'],
+  );
 });
 
-test("tripwire flags but does not block", () => {
-  const notes = [{ path: "maybe.md", text: "see https://internal.example/doc" }];
+test('tripwire flags but does not block', () => {
+  const notes = [{ path: 'maybe.md', text: 'see https://internal.example/doc' }];
   const { blocked, tripwire, clean } = scrubNotes(notes, {
     denylist: [],
-    tripwirePatterns: ["https?://\\S+"],
+    tripwirePatterns: ['https?://\\S+'],
   });
   assert.equal(blocked.length, 0);
-  assert.deepEqual(tripwire.map((t) => t.path), ["maybe.md"]);
-  assert.deepEqual(clean.map((c) => c.path), ["maybe.md"]);
+  assert.deepEqual(
+    tripwire.map((t) => t.path),
+    ['maybe.md'],
+  );
+  assert.deepEqual(
+    clean.map((c) => c.path),
+    ['maybe.md'],
+  );
 });
 
-test("a note both denied and tripwired is blocked (block wins)", () => {
-  const notes = [{ path: "bad.md", text: "NRD at https://x" }];
+test('a note both denied and tripwired is blocked (block wins)', () => {
+  const notes = [{ path: 'bad.md', text: 'NRD at https://x' }];
   const { blocked, clean } = scrubNotes(notes, {
-    denylist: ["nrd"],
-    tripwirePatterns: ["https?://\\S+"],
+    denylist: ['nrd'],
+    tripwirePatterns: ['https?://\\S+'],
   });
-  assert.deepEqual(blocked.map((b) => b.path), ["bad.md"]);
+  assert.deepEqual(
+    blocked.map((b) => b.path),
+    ['bad.md'],
+  );
   assert.equal(clean.length, 0);
 });
 
-test("derived instance facts block even with an empty hand-listed denylist", () => {
-  const notes = [{ path: "leak.md", text: "ref ed25519:OWNKEY and peer thomas" }];
+test('derived instance facts block even with an empty hand-listed denylist', () => {
+  const notes = [{ path: 'leak.md', text: 'ref ed25519:OWNKEY and peer thomas' }];
   const { blocked, clean } = scrubNotes(notes, {
-    denylist: ["thomas", "ed25519:OWNKEY"],
+    denylist: ['thomas', 'ed25519:OWNKEY'],
     tripwirePatterns: [],
   });
-  assert.deepEqual(blocked.map((b) => b.path), ["leak.md"]);
+  assert.deepEqual(
+    blocked.map((b) => b.path),
+    ['leak.md'],
+  );
   assert.equal(clean.length, 0);
 });
 
-test("deny term in the FILENAME blocks even when body is clean (finding 1)", () => {
+test('deny term in the FILENAME blocks even when body is clean (finding 1)', () => {
   const notes = [
-    { path: "project_foster_moore_vue_role.md", text: "a totally generic body about retries" },
-    { path: "clean_note.md", text: "nothing sensitive here" },
+    { path: 'project_foster_moore_vue_role.md', text: 'a totally generic body about retries' },
+    { path: 'clean_note.md', text: 'nothing sensitive here' },
   ];
   const { blocked, clean } = scrubNotes(notes, {
-    denylist: ["foster_moore"],
+    denylist: ['foster_moore'],
     tripwirePatterns: [],
   });
-  assert.deepEqual(blocked.map((b) => b.path), ["project_foster_moore_vue_role.md"]);
-  assert.deepEqual(clean.map((c) => c.path), ["clean_note.md"]);
+  assert.deepEqual(
+    blocked.map((b) => b.path),
+    ['project_foster_moore_vue_role.md'],
+  );
+  assert.deepEqual(
+    clean.map((c) => c.path),
+    ['clean_note.md'],
+  );
 });
 
-test("deny term matches hyphen/underscore compounds (finding 2)", () => {
+test('deny term matches hyphen/underscore compounds (finding 2)', () => {
   const notes = [
-    { path: "a.md", text: "we shipped the acme-registry integration" },
-    { path: "b.md", text: "notes on acme_registry internals" },
-    { path: "c.md", text: "an unrelated acmecorp mention should NOT match" },
+    { path: 'a.md', text: 'we shipped the acme-registry integration' },
+    { path: 'b.md', text: 'notes on acme_registry internals' },
+    { path: 'c.md', text: 'an unrelated acmecorp mention should NOT match' },
   ];
   const { blocked, clean } = scrubNotes(notes, {
-    denylist: ["acme"],
+    denylist: ['acme'],
     tripwirePatterns: [],
   });
-  assert.deepEqual(blocked.map((b) => b.path).sort(), ["a.md", "b.md"]);
-  assert.deepEqual(clean.map((c) => c.path), ["c.md"]);
+  assert.deepEqual(blocked.map((b) => b.path).sort(), ['a.md', 'b.md']);
+  assert.deepEqual(
+    clean.map((c) => c.path),
+    ['c.md'],
+  );
 });
 
-test("word-boundary still does not match inside an alphanumeric word after the fix", () => {
+test('word-boundary still does not match inside an alphanumeric word after the fix', () => {
   // regression guard for the original finding: 'ai' must not match 'maintainer'
-  const notes = [{ path: "x.md", text: "the maintainer fixed a domain bug" }];
-  const { blocked, clean } = scrubNotes(notes, { denylist: ["ai"], tripwirePatterns: [] });
+  const notes = [{ path: 'x.md', text: 'the maintainer fixed a domain bug' }];
+  const { blocked, clean } = scrubNotes(notes, { denylist: ['ai'], tripwirePatterns: [] });
   assert.equal(blocked.length, 0);
-  assert.deepEqual(clean.map((c) => c.path), ["x.md"]);
+  assert.deepEqual(
+    clean.map((c) => c.path),
+    ['x.md'],
+  );
 });
 
-test("CLI reads note paths from stdin when no path args given", () => {
-  const dir = mkdtempSync(join(tmpdir(), "ll-scrub-cli-"));
+test('CLI reads note paths from stdin when no path args given', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'll-scrub-cli-'));
   try {
-    const ok = join(dir, "ok.md");
-    const leak = join(dir, "leak.md");
-    const deny = join(dir, "deny.txt");
-    writeFileSync(ok, "a generic retry lesson");
-    writeFileSync(leak, "we used NRD at work");
-    writeFileSync(deny, "nrd\n");
-    const scrubScript = new URL("../plugin/scripts/harvest-scrub.mjs", import.meta.url).pathname;
+    const ok = join(dir, 'ok.md');
+    const leak = join(dir, 'leak.md');
+    const deny = join(dir, 'deny.txt');
+    writeFileSync(ok, 'a generic retry lesson');
+    writeFileSync(leak, 'we used NRD at work');
+    writeFileSync(deny, 'nrd\n');
+    const scrubScript = fileURLToPath(
+      new URL('../plugin/scripts/harvest-scrub.mjs', import.meta.url),
+    );
     const out = execFileSync(
       process.execPath,
-      [scrubScript, deny, ""],            // empty pluginData => no derived facts
-      { input: `${ok}\n${leak}\n`, encoding: "utf8" },
+      [scrubScript, deny, ''], // empty pluginData => no derived facts
+      { input: `${ok}\n${leak}\n`, encoding: 'utf8' },
     );
     const result = JSON.parse(out);
-    assert.deepEqual(result.blocked.map((b) => b.path), [leak]);
-    assert.deepEqual(result.clean.map((c) => c.path), [ok]);
+    assert.deepEqual(
+      result.blocked.map((b) => b.path),
+      [leak],
+    );
+    assert.deepEqual(
+      result.clean.map((c) => c.path),
+      [ok],
+    );
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
 });
 
-test("CLI blocks an instance domain even when email_domains is a bare string (not array)", () => {
+test('CLI blocks an instance domain even when email_domains is a bare string (not array)', () => {
   // B1: a string-typed email_domains must not shred into single chars that fail
   // to block the company domain. The note must be BLOCKED, never land in clean.
-  const dir = mkdtempSync(join(tmpdir(), "ll-scrub-str-"));
+  const dir = mkdtempSync(join(tmpdir(), 'll-scrub-str-'));
   try {
-    const note = join(dir, "leak.md");
-    const deny = join(dir, "deny.txt");
-    writeFileSync(note, "we standardised on acmecorp.com for everything");
-    writeFileSync(deny, "");
-    writeFileSync(join(dir, "config.json"), JSON.stringify({ email_domains: "acmecorp.com" }));
-    const scrubScript = new URL("../plugin/scripts/harvest-scrub.mjs", import.meta.url).pathname;
+    const note = join(dir, 'leak.md');
+    const deny = join(dir, 'deny.txt');
+    writeFileSync(note, 'we standardised on acmecorp.com for everything');
+    writeFileSync(deny, '');
+    writeFileSync(join(dir, 'config.json'), JSON.stringify({ email_domains: 'acmecorp.com' }));
+    const scrubScript = fileURLToPath(
+      new URL('../plugin/scripts/harvest-scrub.mjs', import.meta.url),
+    );
     const out = execFileSync(process.execPath, [scrubScript, deny, dir], {
       input: `${note}\n`,
-      encoding: "utf8",
+      encoding: 'utf8',
       env: { ...process.env, CLAUDE_PLUGIN_DATA: dir },
     });
     const result = JSON.parse(out);
-    assert.deepEqual(result.blocked.map((b) => b.path), [note]);
-    assert.deepEqual(result.clean.map((c) => c.path), []);
+    assert.deepEqual(
+      result.blocked.map((b) => b.path),
+      [note],
+    );
+    assert.deepEqual(
+      result.clean.map((c) => c.path),
+      [],
+    );
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
 });
 
-test("CLI fails closed (non-zero exit, no clean output) when email_domains is a non-coercible object", () => {
+test('CLI fails closed (non-zero exit, no clean output) when email_domains is a non-coercible object', () => {
   // M1: an object email_domains used to throw an uncaught TypeError before any
   // JSON was written — the operator saw nothing. It must now fail closed: a clear
   // error on stderr and a non-zero exit, never a partial/empty report read as success.
-  const dir = mkdtempSync(join(tmpdir(), "ll-scrub-obj-"));
+  const dir = mkdtempSync(join(tmpdir(), 'll-scrub-obj-'));
   try {
-    const note = join(dir, "leak.md");
-    const deny = join(dir, "deny.txt");
-    writeFileSync(note, "we used acmecorp.com");
-    writeFileSync(deny, "");
-    writeFileSync(join(dir, "config.json"), JSON.stringify({ email_domains: { a: "acmecorp.com" } }));
-    const scrubScript = new URL("../plugin/scripts/harvest-scrub.mjs", import.meta.url).pathname;
+    const note = join(dir, 'leak.md');
+    const deny = join(dir, 'deny.txt');
+    writeFileSync(note, 'we used acmecorp.com');
+    writeFileSync(deny, '');
+    writeFileSync(
+      join(dir, 'config.json'),
+      JSON.stringify({ email_domains: { a: 'acmecorp.com' } }),
+    );
+    const scrubScript = fileURLToPath(
+      new URL('../plugin/scripts/harvest-scrub.mjs', import.meta.url),
+    );
     let threw = false;
-    let stderr = "";
+    let stderr = '';
     try {
       execFileSync(process.execPath, [scrubScript, deny, dir], {
         input: `${note}\n`,
-        encoding: "utf8",
+        encoding: 'utf8',
         env: { ...process.env, CLAUDE_PLUGIN_DATA: dir },
       });
     } catch (e) {
       threw = true;
-      stderr = String(e.stderr || "");
+      stderr = String(e.stderr || '');
     }
-    assert.ok(threw, "scrub CLI must exit non-zero on a non-coercible email_domains config");
-    assert.match(stderr, /email_domains/, "error must name the offending config key");
+    assert.ok(threw, 'scrub CLI must exit non-zero on a non-coercible email_domains config');
+    assert.match(stderr, /email_domains/, 'error must name the offending config key');
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
 });
 
-test("CLI exits 1 when config.json exists but is unparseable (fail closed)", () => {
+test('CLI exits 1 when config.json exists but is unparseable (fail closed)', () => {
   // getConfigStrict resolves the config via CLAUDE_PLUGIN_DATA (getPluginData),
   // NOT via the argv pluginData — without the env the CLI would read the real
   // repo config and exit 0.
-  const dir = mkdtempSync(join(tmpdir(), "ll-scrub-badcfg-"));
+  const dir = mkdtempSync(join(tmpdir(), 'll-scrub-badcfg-'));
   try {
-    const note = join(dir, "clean-note.md");
-    const deny = join(dir, "deny.txt");
-    writeFileSync(note, "nothing sensitive here");
-    writeFileSync(deny, "");
-    writeFileSync(join(dir, "config.json"), "{ this is not json");
-    const scrubScript = new URL("../plugin/scripts/harvest-scrub.mjs", import.meta.url).pathname;
+    const note = join(dir, 'clean-note.md');
+    const deny = join(dir, 'deny.txt');
+    writeFileSync(note, 'nothing sensitive here');
+    writeFileSync(deny, '');
+    writeFileSync(join(dir, 'config.json'), '{ this is not json');
+    const scrubScript = fileURLToPath(
+      new URL('../plugin/scripts/harvest-scrub.mjs', import.meta.url),
+    );
     const res = spawnSync(process.execPath, [scrubScript, deny, dir, note], {
-      encoding: "utf8",
+      encoding: 'utf8',
       env: { ...process.env, CLAUDE_PLUGIN_DATA: dir },
     });
     assert.equal(res.status, 1);
     assert.match(res.stderr, /config/i);
-    assert.ok(!res.stdout.includes('"clean"'), "no report at all on a corrupt config");
+    assert.ok(!res.stdout.includes('"clean"'), 'no report at all on a corrupt config');
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
 });
 
-test("CLI exits 1 when federation config exists but is unparseable", () => {
+test('CLI exits 1 when federation config exists but is unparseable', () => {
   // Main config.json is VALID here, pinning the exercised failure to the
   // federation one (FEDERATION_PATHS.config = <pluginData>/federation/config.json).
-  const dir = mkdtempSync(join(tmpdir(), "ll-scrub-badfed-"));
+  const dir = mkdtempSync(join(tmpdir(), 'll-scrub-badfed-'));
   try {
-    const note = join(dir, "clean-note.md");
-    const deny = join(dir, "deny.txt");
-    writeFileSync(note, "nothing sensitive here");
-    writeFileSync(deny, "");
-    writeFileSync(join(dir, "config.json"), "{}");
-    mkdirSync(join(dir, "federation"), { recursive: true });
-    writeFileSync(join(dir, "federation", "config.json"), "{nope");
-    const scrubScript = new URL("../plugin/scripts/harvest-scrub.mjs", import.meta.url).pathname;
+    const note = join(dir, 'clean-note.md');
+    const deny = join(dir, 'deny.txt');
+    writeFileSync(note, 'nothing sensitive here');
+    writeFileSync(deny, '');
+    writeFileSync(join(dir, 'config.json'), '{}');
+    mkdirSync(join(dir, 'federation'), { recursive: true });
+    writeFileSync(join(dir, 'federation', 'config.json'), '{nope');
+    const scrubScript = fileURLToPath(
+      new URL('../plugin/scripts/harvest-scrub.mjs', import.meta.url),
+    );
     const res = spawnSync(process.execPath, [scrubScript, deny, dir, note], {
-      encoding: "utf8",
+      encoding: 'utf8',
       env: { ...process.env, CLAUDE_PLUGIN_DATA: dir },
     });
     assert.equal(res.status, 1);
@@ -234,19 +305,21 @@ test("CLI exits 1 when federation config exists but is unparseable", () => {
   }
 });
 
-test("CLI exits 1 when config.json contains literal null (not an object)", () => {
+test('CLI exits 1 when config.json contains literal null (not an object)', () => {
   // Valid JSON `null` parses cleanly but vanishes email_domains with no error —
   // corrupt for gate purposes, not a default.
-  const dir = mkdtempSync(join(tmpdir(), "ll-scrub-nullcfg-"));
+  const dir = mkdtempSync(join(tmpdir(), 'll-scrub-nullcfg-'));
   try {
-    const note = join(dir, "clean-note.md");
-    const deny = join(dir, "deny.txt");
-    writeFileSync(note, "nothing sensitive here");
-    writeFileSync(deny, "");
-    writeFileSync(join(dir, "config.json"), "null");
-    const scrubScript = new URL("../plugin/scripts/harvest-scrub.mjs", import.meta.url).pathname;
+    const note = join(dir, 'clean-note.md');
+    const deny = join(dir, 'deny.txt');
+    writeFileSync(note, 'nothing sensitive here');
+    writeFileSync(deny, '');
+    writeFileSync(join(dir, 'config.json'), 'null');
+    const scrubScript = fileURLToPath(
+      new URL('../plugin/scripts/harvest-scrub.mjs', import.meta.url),
+    );
     const res = spawnSync(process.execPath, [scrubScript, deny, dir, note], {
-      encoding: "utf8",
+      encoding: 'utf8',
       env: { ...process.env, CLAUDE_PLUGIN_DATA: dir },
     });
     assert.equal(res.status, 1);
@@ -256,17 +329,19 @@ test("CLI exits 1 when config.json contains literal null (not an object)", () =>
   }
 });
 
-test("CLI exits 1 when config.json contains an array (not an object)", () => {
-  const dir = mkdtempSync(join(tmpdir(), "ll-scrub-arrcfg-"));
+test('CLI exits 1 when config.json contains an array (not an object)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'll-scrub-arrcfg-'));
   try {
-    const note = join(dir, "clean-note.md");
-    const deny = join(dir, "deny.txt");
-    writeFileSync(note, "nothing sensitive here");
-    writeFileSync(deny, "");
-    writeFileSync(join(dir, "config.json"), "[1,2]");
-    const scrubScript = new URL("../plugin/scripts/harvest-scrub.mjs", import.meta.url).pathname;
+    const note = join(dir, 'clean-note.md');
+    const deny = join(dir, 'deny.txt');
+    writeFileSync(note, 'nothing sensitive here');
+    writeFileSync(deny, '');
+    writeFileSync(join(dir, 'config.json'), '[1,2]');
+    const scrubScript = fileURLToPath(
+      new URL('../plugin/scripts/harvest-scrub.mjs', import.meta.url),
+    );
     const res = spawnSync(process.execPath, [scrubScript, deny, dir, note], {
-      encoding: "utf8",
+      encoding: 'utf8',
       env: { ...process.env, CLAUDE_PLUGIN_DATA: dir },
     });
     assert.equal(res.status, 1);
@@ -276,16 +351,19 @@ test("CLI exits 1 when config.json contains an array (not an object)", () => {
   }
 });
 
-test("numeric deny term is coerced and still blocks", () => {
-  const { blocked } = scrubNotes(
-    [{ path: "a.md", text: "project code 4711 is secret" }],
-    { denylist: [4711], tripwirePatterns: [] },
-  );
+test('numeric deny term is coerced and still blocks', () => {
+  const { blocked } = scrubNotes([{ path: 'a.md', text: 'project code 4711 is secret' }], {
+    denylist: [4711],
+    tripwirePatterns: [],
+  });
   assert.equal(blocked.length, 1);
 });
 
-test("object deny term throws (fail closed, never silently dropped)", () => {
+test('object deny term throws (fail closed, never silently dropped)', () => {
   assert.throws(() =>
-    scrubNotes([{ path: "a.md", text: "x" }], { denylist: [{ term: "acme" }], tripwirePatterns: [] }),
+    scrubNotes([{ path: 'a.md', text: 'x' }], {
+      denylist: [{ term: 'acme' }],
+      tripwirePatterns: [],
+    }),
   );
 });

--- a/tests/helpers/hook-runner.mjs
+++ b/tests/helpers/hook-runner.mjs
@@ -3,7 +3,17 @@
 // Each invocation gets a fresh temp sandbox for HOME and plugin-data.
 
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, readdirSync, readFileSync, writeFileSync, rmSync, existsSync, statSync, symlinkSync } from 'node:fs';
+import {
+  mkdtempSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+  rmSync,
+  existsSync,
+  statSync,
+  symlinkSync,
+} from 'node:fs';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
@@ -191,13 +201,7 @@ function reapRecordedChildren(pidFile) {
  * }}
  */
 export function runHook(hookPath, opts = {}) {
-  const {
-    stdin = '',
-    env = {},
-    cwd,
-    timeoutMs = 8000,
-    seed,
-  } = opts;
+  const { stdin = '', env = {}, cwd, timeoutMs = 8000, seed } = opts;
 
   // Allocate per-call sandbox so nothing leaks across tests.
   const sandboxRoot = mkdtempSync(join(tmpdir(), 'll-hook-sb-'));
@@ -280,6 +284,10 @@ export function runHook(hookPath, opts = {}) {
       LL_CHILD_PID_FILE: childPidFile,
       // Consumer-provided overrides (VAULT_PATH, CLAUDE_PROJECT_DIR, etc.).
       ...env,
+      // os.tmpdir() reads $TMPDIR on POSIX but %TEMP%/%TMP% on Windows. Mirror
+      // a consumer TMPDIR override onto both so tmp redirection works on every
+      // platform (otherwise the hook scans the real Temp the test never seeded).
+      ...(env.TMPDIR ? { TEMP: env.TMPDIR, TMP: env.TMPDIR } : {}),
     },
   });
 

--- a/tests/hook-fail-mode.test.mjs
+++ b/tests/hook-fail-mode.test.mjs
@@ -8,6 +8,7 @@ import assert from 'node:assert/strict';
 import { mkdirSync, writeFileSync, rmSync, mkdtempSync, chmodSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
 import { preWriteFailMode } from '../plugin/scripts/lib/hook-config.mjs';
 import { runHook } from './helpers/hook-runner.mjs';
 import { skipOnWindows } from './helpers/platform.mjs';
@@ -51,7 +52,7 @@ describe('preWriteFailMode()', () => {
 
 // --- Integration tests: fail-mode wiring in pre-write-check.js ---
 
-const HOOK = new URL('../plugin/hooks/pre-write-check.js', import.meta.url).pathname;
+const HOOK = fileURLToPath(new URL('../plugin/hooks/pre-write-check.js', import.meta.url));
 const SKIP = skipOnWindows('UDS socket / subprocess: skipped on win32');
 
 // A Write payload with a title (triggers the duplicate gate) and no

--- a/tests/hook-post-tool.test.mjs
+++ b/tests/hook-post-tool.test.mjs
@@ -4,6 +4,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { fileURLToPath } from 'node:url';
+import { encodeProjectDir } from '../plugin/scripts/lib/paths.mjs';
 import {
   readFileSync,
   readdirSync,
@@ -133,7 +134,7 @@ test('post-tool module order: load-bearing before enrichment, autolink before ed
 // to the sandbox root.
 test('post-tool Write into the memory dir records a session-scoped write-log entry', () => {
   const projectDir = mkdtempSync(join(tmpdir(), 'll-pt-mem-proj-'));
-  const encodedPath = projectDir.replace(/[/\\]/g, '-');
+  const encodedPath = encodeProjectDir(projectDir);
   const sid = 'pt-mem-session';
   // The harness redirects HOME to sandboxRoot, so the memory dir path is
   // deterministic from sandboxRoot + the encoded project dir.

--- a/tests/hook-pre-compact.test.mjs
+++ b/tests/hook-pre-compact.test.mjs
@@ -7,8 +7,9 @@ import { existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { runHook } from './helpers/hook-runner.mjs';
+import { fileURLToPath } from 'node:url';
 
-const HOOK = new URL('../plugin/hooks/pre-compact.js', import.meta.url).pathname;
+const HOOK = fileURLToPath(new URL('../plugin/hooks/pre-compact.js', import.meta.url));
 
 // -- helpers --
 
@@ -45,7 +46,11 @@ test('pre-compact stdin ignored: output identical regardless of stdin content', 
   try {
     assert.equal(r1.exitCode, 0);
     assert.equal(r2.exitCode, 0);
-    assert.equal(r1.stdout.trim(), r2.stdout.trim(), 'output must be identical regardless of stdin');
+    assert.equal(
+      r1.stdout.trim(),
+      r2.stdout.trim(),
+      'output must be identical regardless of stdin',
+    );
   } finally {
     r1.cleanup();
     r2.cleanup();

--- a/tests/hook-runner-child-reap.test.mjs
+++ b/tests/hook-runner-child-reap.test.mjs
@@ -10,9 +10,10 @@ import { existsSync, readFileSync, writeFileSync, mkdtempSync, rmSync } from 'no
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { runHook } from './helpers/hook-runner.mjs';
+import { fileURLToPath } from 'node:url';
 
-const HOOK = new URL('../plugin/hooks/session-start.js', import.meta.url).pathname;
-const VAULT = new URL('./fixtures/vault-small', import.meta.url).pathname;
+const HOOK = fileURLToPath(new URL('../plugin/hooks/session-start.js', import.meta.url));
+const VAULT = fileURLToPath(new URL('./fixtures/vault-small', import.meta.url));
 
 // Fresh update-check.json so the hook does not spawn the background
 // update-check child that would hit api.github.com.
@@ -28,40 +29,36 @@ function seedUpdateCheck(pluginDataDir) {
   );
 }
 
-test(
-  'session-start records detached child pids and cleanup reaps them',
-  { timeout: 12000 },
-  () => {
-    // With a vault + CLAUDE_PLUGIN_DATA present, context-assembly spawns the
-    // intentions worker, the dream-gate refresh, and the provenance emitter
-    // unconditionally — at least one recorded pid is guaranteed.
-    const r = runHook(HOOK, {
-      stdin: { session_id: 'child-reap-001' },
-      env: { VAULT_PATH: VAULT },
-      seed: (pd) => seedUpdateCheck(pd),
-    });
-    const pidFile = join(r.sandboxRoot, '.child-pids');
-    try {
-      assert.equal(r.exitCode, 0, r.stderr);
-      assert.ok(existsSync(pidFile), 'detached children must be recorded');
-      const pids = readFileSync(pidFile, 'utf8').split('\n').filter(Boolean).map(Number);
-      assert.ok(pids.length >= 1, 'at least one detached child recorded');
-      r.cleanup();
-      for (const pid of pids) {
-        let alive = true;
-        try {
-          process.kill(pid, 0);
-        } catch {
-          alive = false;
-        }
-        assert.ok(!alive, `child ${pid} must be dead after cleanup`);
+test('session-start records detached child pids and cleanup reaps them', { timeout: 12000 }, () => {
+  // With a vault + CLAUDE_PLUGIN_DATA present, context-assembly spawns the
+  // intentions worker, the dream-gate refresh, and the provenance emitter
+  // unconditionally — at least one recorded pid is guaranteed.
+  const r = runHook(HOOK, {
+    stdin: { session_id: 'child-reap-001' },
+    env: { VAULT_PATH: VAULT },
+    seed: (pd) => seedUpdateCheck(pd),
+  });
+  const pidFile = join(r.sandboxRoot, '.child-pids');
+  try {
+    assert.equal(r.exitCode, 0, r.stderr);
+    assert.ok(existsSync(pidFile), 'detached children must be recorded');
+    const pids = readFileSync(pidFile, 'utf8').split('\n').filter(Boolean).map(Number);
+    assert.ok(pids.length >= 1, 'at least one detached child recorded');
+    r.cleanup();
+    for (const pid of pids) {
+      let alive = true;
+      try {
+        process.kill(pid, 0);
+      } catch {
+        alive = false;
       }
-    } finally {
-      // cleanup() may already have run; calling twice is safe (rmSync force).
-      r.cleanup();
+      assert.ok(!alive, `child ${pid} must be dead after cleanup`);
     }
-  },
-);
+  } finally {
+    // cleanup() may already have run; calling twice is safe (rmSync force).
+    r.cleanup();
+  }
+});
 
 test(
   'cleanup kills a recorded child that would otherwise outlive the test',

--- a/tests/hook-runner-sandbox.test.mjs
+++ b/tests/hook-runner-sandbox.test.mjs
@@ -8,12 +8,21 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, writeFileSync, readFileSync, existsSync, utimesSync, rmSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  utimesSync,
+  rmSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { runHook, sweepStaleSandboxes } from './helpers/hook-runner.mjs';
+import { fileURLToPath } from 'node:url';
 
-const HOOK = new URL('../plugin/hooks/pre-write-check.js', import.meta.url).pathname;
+const HOOK = fileURLToPath(new URL('../plugin/hooks/pre-write-check.js', import.meta.url));
 const PKG = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
 
 // A non-Write tool makes pre-write-check exit immediately — cheapest real hook.

--- a/tests/hook-session-start-stale-sweep.test.mjs
+++ b/tests/hook-session-start-stale-sweep.test.mjs
@@ -14,6 +14,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
 import {
   mkdtempSync,
   mkdirSync,
@@ -32,8 +33,8 @@ import { run } from '../plugin/hooks/session-start/vault-snapshot.mjs';
 import { HookConfig } from '../plugin/scripts/lib/hook-config.mjs';
 import { runHook } from './helpers/hook-runner.mjs';
 
-const HOOK = new URL('../plugin/hooks/session-start.js', import.meta.url).pathname;
-const VAULT = new URL('./fixtures/vault-small', import.meta.url).pathname;
+const HOOK = fileURLToPath(new URL('../plugin/hooks/session-start.js', import.meta.url));
+const VAULT = fileURLToPath(new URL('./fixtures/vault-small', import.meta.url));
 
 function makeFixture({ version = '1.25.1' } = {}) {
   const sb = mkdtempSync(join(tmpdir(), 'll-sweep-'));
@@ -76,11 +77,9 @@ function ageFile(path, ms) {
 
 test('sweep: removes orphaned ll-search.*-bak binaries', async () => {
   const fx = makeFixture();
-  const baks = [
-    'll-search.preDelta-bak',
-    'll-search.preDelta2-bak',
-    'll-search.preDelta3-bak',
-  ].map((n) => join(fx.binDir, n));
+  const baks = ['ll-search.preDelta-bak', 'll-search.preDelta2-bak', 'll-search.preDelta3-bak'].map(
+    (n) => join(fx.binDir, n),
+  );
   for (const p of baks) writeFileSync(p, 'stale-binary-bytes');
 
   await withSandbox(fx, async () => {
@@ -183,10 +182,7 @@ test(
         existsSync(join(r.pluginDataDir, 'markers', 'memory-snapshot-fresh')),
         'fresh marker kept',
       );
-      assert.ok(
-        !existsSync(join(r.pluginDataDir, 'edges.db.12345.tmp')),
-        'edges tmp orphan swept',
-      );
+      assert.ok(!existsSync(join(r.pluginDataDir, 'edges.db.12345.tmp')), 'edges tmp orphan swept');
       assert.deepEqual(
         readdirSync(isolatedTmp).sort(),
         ['learning-loop-session-id'],
@@ -236,10 +232,7 @@ test('TTL sweep is gated to once per 24h — a stale marker survives a same-day 
     writeFileSync(stale2, '[]');
     utimesSync(stale2, eightDaysAgo, eightDaysAgo);
     await run({ ...baseCtx });
-    assert.ok(
-      existsSync(stale2),
-      'second same-day run is gated — the stale marker survives',
-    );
+    assert.ok(existsSync(stale2), 'second same-day run is gated — the stale marker survives');
   });
   rmSync(isolatedTmp, { recursive: true, force: true });
 });

--- a/tests/hook-session-start.test.mjs
+++ b/tests/hook-session-start.test.mjs
@@ -21,6 +21,7 @@ import {
 import { join, resolve, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { runHook } from './helpers/hook-runner.mjs';
+import { skipOnWindows } from './helpers/platform.mjs';
 
 const HOOK = fileURLToPath(new URL('../plugin/hooks/session-start.js', import.meta.url));
 const VAULT = fileURLToPath(new URL('./fixtures/vault-small', import.meta.url));
@@ -549,37 +550,46 @@ test(
 // EEXIST as "locked forever" — otherwise vault indexing is silently disabled
 // on every later session.
 // ---------------------------------------------------------------------------
-test('watch-daemon recovers from a crashed spawn lock — M12', { timeout: 12000 }, () => {
-  const vaultDir = mkdtempSync(join(realpathSync(tmpdir()), 'll-wd-vault-'));
-  const vsDir = join(vaultDir, '.vault-search');
-  mkdirSync(vsDir, { recursive: true });
-  writeFileSync(join(vsDir, 'vault-index.db'), '');
-  // Crashed previous session: lock file with a dead pid, old mtime.
-  writeFileSync(join(vsDir, 'watch.pid.lock'), '2147483647');
-  const old = (Date.now() - 2 * 60 * 60 * 1000) / 1000;
-  utimesSync(join(vsDir, 'watch.pid.lock'), old, old);
+test(
+  'watch-daemon recovers from a crashed spawn lock — M12',
+  {
+    timeout: 12000,
+    skip: skipOnWindows(
+      'shebang stub: #!/bin/sh ll-search stub is not an executable ll-search.exe on win32',
+    ),
+  },
+  () => {
+    const vaultDir = mkdtempSync(join(realpathSync(tmpdir()), 'll-wd-vault-'));
+    const vsDir = join(vaultDir, '.vault-search');
+    mkdirSync(vsDir, { recursive: true });
+    writeFileSync(join(vsDir, 'vault-index.db'), '');
+    // Crashed previous session: lock file with a dead pid, old mtime.
+    writeFileSync(join(vsDir, 'watch.pid.lock'), '2147483647');
+    const old = (Date.now() - 2 * 60 * 60 * 1000) / 1000;
+    utimesSync(join(vsDir, 'watch.pid.lock'), old, old);
 
-  const r = runHook(HOOK, {
-    env: { VAULT_PATH: vaultDir },
-    stdin: '',
-    seed: (pluginDataDir) => {
-      seedUpdateCheck(pluginDataDir);
-      const bin = join(pluginDataDir, 'bin', 'll-search');
-      writeFileSync(bin, '#!/bin/sh\nexit 0\n', { mode: 0o755 });
-    },
-  });
-  try {
-    assert.equal(r.exitCode, 0, r.stderr);
-    assert.ok(
-      existsSync(join(vsDir, 'watch.fingerprint')),
-      'daemon spawn path must proceed past a stale lock (fingerprint written)',
-    );
-    assert.ok(!existsSync(join(vsDir, 'watch.pid.lock')), 'lock released after spawn');
-  } finally {
-    r.cleanup();
-    rmSync(vaultDir, { recursive: true, force: true });
-  }
-});
+    const r = runHook(HOOK, {
+      env: { VAULT_PATH: vaultDir },
+      stdin: '',
+      seed: (pluginDataDir) => {
+        seedUpdateCheck(pluginDataDir);
+        const bin = join(pluginDataDir, 'bin', 'll-search');
+        writeFileSync(bin, '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+      },
+    });
+    try {
+      assert.equal(r.exitCode, 0, r.stderr);
+      assert.ok(
+        existsSync(join(vsDir, 'watch.fingerprint')),
+        'daemon spawn path must proceed past a stale lock (fingerprint written)',
+      );
+      assert.ok(!existsSync(join(vsDir, 'watch.pid.lock')), 'lock released after spawn');
+    } finally {
+      r.cleanup();
+      rmSync(vaultDir, { recursive: true, force: true });
+    }
+  },
+);
 
 // ---------------------------------------------------------------------------
 // Regression (W5/6b): the post-acquire re-probe treated only 'alive' as
@@ -628,7 +638,12 @@ test('watch-daemon does not spawn over a writer-in-progress pidfile', { timeout:
 // ---------------------------------------------------------------------------
 test(
   'watch-daemon spawn is recorded in the detached-child pidfile',
-  { timeout: 12000 },
+  {
+    timeout: 12000,
+    skip: skipOnWindows(
+      'shebang stub: #!/bin/sh ll-search stub is not an executable ll-search.exe on win32',
+    ),
+  },
   async () => {
     const vaultDir = mkdtempSync(join(realpathSync(tmpdir()), 'll-wd-rec-'));
     const vsDir = join(vaultDir, '.vault-search');

--- a/tests/hook-session-start.test.mjs
+++ b/tests/hook-session-start.test.mjs
@@ -5,6 +5,8 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import { encodeProjectDir } from '../plugin/scripts/lib/paths.mjs';
 import {
   writeFileSync,
   readFileSync,
@@ -20,8 +22,8 @@ import { join, resolve, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { runHook } from './helpers/hook-runner.mjs';
 
-const HOOK = new URL('../plugin/hooks/session-start.js', import.meta.url).pathname;
-const VAULT = new URL('./fixtures/vault-small', import.meta.url).pathname;
+const HOOK = fileURLToPath(new URL('../plugin/hooks/session-start.js', import.meta.url));
+const VAULT = fileURLToPath(new URL('./fixtures/vault-small', import.meta.url));
 
 // Seed update-check.json with a fresh timestamp so the hook does NOT spawn
 // the background update-check child that would hit api.github.com.
@@ -298,7 +300,7 @@ test(
       env: { VAULT_PATH: VAULT, CLAUDE_PROJECT_DIR: '/tmp/test-project-stale' },
       seed: (pd, sb) => {
         seedUpdateCheck(pd);
-        const encoded = '/tmp/test-project-stale'.replace(/[/\\]/g, '-');
+        const encoded = encodeProjectDir('/tmp/test-project-stale');
         const memDir = join(sb, '.claude', 'projects', encoded, 'memory');
         mkdirSync(memDir, { recursive: true });
         const memPath = join(memDir, 'MEMORY.md');
@@ -326,7 +328,7 @@ test('session-start memory: injects MEMORY.md when mtime within 7 days', { timeo
     env: { VAULT_PATH: VAULT, CLAUDE_PROJECT_DIR: '/tmp/test-project-fresh' },
     seed: (pd, sb) => {
       seedUpdateCheck(pd);
-      const encoded = '/tmp/test-project-fresh'.replace(/[/\\]/g, '-');
+      const encoded = encodeProjectDir('/tmp/test-project-fresh');
       const memDir = join(sb, '.claude', 'projects', encoded, 'memory');
       mkdirSync(memDir, { recursive: true });
       const memPath = join(memDir, 'MEMORY.md');
@@ -360,7 +362,7 @@ test(
       },
       seed: (pd, sb) => {
         seedUpdateCheck(pd);
-        const encoded = '/tmp/test-project-override'.replace(/[/\\]/g, '-');
+        const encoded = encodeProjectDir('/tmp/test-project-override');
         const memDir = join(sb, '.claude', 'projects', encoded, 'memory');
         mkdirSync(memDir, { recursive: true });
         const memPath = join(memDir, 'MEMORY.md');
@@ -394,7 +396,7 @@ test(
         // Arrange: oversized GLOBAL memory index, mtime fresh (now). Line-oriented
         // content so the cap cuts on a newline. The global memory path keys on the
         // vault PARENT, mirroring context-assembly.mjs.
-        const encodedVaultParent = resolve(VAULT, '..').replace(/[/\\]/g, '-');
+        const encodedVaultParent = encodeProjectDir(resolve(VAULT, '..'));
         const globalMemoryPath = join(
           sb,
           '.claude',
@@ -510,7 +512,7 @@ test(
   () => {
     const projectDir = mkdtempSync(join(tmpdir(), 'll-ss-proj-'));
     const isolatedTmp = mkdtempSync(join(tmpdir(), 'll-ss-m4-'));
-    const encodedPath = projectDir.replace(/[/\\]/g, '-');
+    const encodedPath = encodeProjectDir(projectDir);
     const r = runHook(HOOK, {
       env: {
         VAULT_PATH: VAULT,
@@ -694,7 +696,7 @@ test(
       env: { VAULT_PATH: VAULT, CLAUDE_PROJECT_DIR: vaultParent },
       seed: (pd, sb) => {
         seedUpdateCheck(pd);
-        const encoded = vaultParent.replace(/[/\\]/g, '-');
+        const encoded = encodeProjectDir(vaultParent);
         const memDir = join(sb, '.claude', 'projects', encoded, 'memory');
         mkdirSync(memDir, { recursive: true });
         // Single occurrence of the marker per injection (a [x](x) link would
@@ -744,11 +746,11 @@ test(
         // lines at the END of each — if either index is even partially
         // trimmed, its sentinel dies.
         const memFiller = ('- [n](n.md) — ' + 'y'.repeat(80) + '\n').repeat(10);
-        const encodedProject = projectDir.replace(/[/\\]/g, '-');
+        const encodedProject = encodeProjectDir(projectDir);
         const projMemDir = join(sb, '.claude', 'projects', encodedProject, 'memory');
         mkdirSync(projMemDir, { recursive: true });
         writeFileSync(join(projMemDir, 'MEMORY.md'), memFiller + '- PROJECT-MEM-SENTINEL\n');
-        const encodedVaultParent = resolve(VAULT, '..').replace(/[/\\]/g, '-');
+        const encodedVaultParent = encodeProjectDir(resolve(VAULT, '..'));
         const globalMemDir = join(sb, '.claude', 'projects', encodedVaultParent, 'memory');
         mkdirSync(globalMemDir, { recursive: true });
         writeFileSync(join(globalMemDir, 'MEMORY.md'), memFiller + '- GLOBAL-MEM-SENTINEL\n');

--- a/tests/hook-stop-nudge.test.mjs
+++ b/tests/hook-stop-nudge.test.mjs
@@ -15,12 +15,14 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { skipOnWindows } from './helpers/platform.mjs';
 import { runHook } from './helpers/hook-runner.mjs';
+import { fileURLToPath } from 'node:url';
+import { encodeProjectDir } from '../plugin/scripts/lib/paths.mjs';
 
-const HOOK = new URL('../plugin/hooks/stop-nudge.js', import.meta.url).pathname;
+const HOOK = fileURLToPath(new URL('../plugin/hooks/stop-nudge.js', import.meta.url));
 
-// On macOS, the hook child uses /tmp (the symlink) as its tmpdir().
-// Use this consistent path for pre-seeded markers and cleanup.
-const HOOK_TMP = '/tmp';
+// Mirror the hook child's tmpdir() so pre-seeded markers and transcript
+// fixtures land where the hook resolves them on every platform.
+const HOOK_TMP = tmpdir();
 
 // Write a transcript of exactly `size` bytes to `path`.
 function writeTranscript(path, size) {
@@ -221,7 +223,7 @@ test('reflect cooldown read from plugin-data suppresses the nudge — M2', () =>
 
 test('dream nudge fires on >=3 new memories, then respects its once-guard — M3/M4', () => {
   const projectDir = mkdtempSync(join(tmpdir(), 'll-sn-proj-'));
-  const encodedPath = projectDir.replace(/[/\\]/g, '-');
+  const encodedPath = encodeProjectDir(projectDir);
   const sid = 'test-dream-nudge';
 
   const seed = (pluginDataDir, sandboxRoot) => {
@@ -318,7 +320,7 @@ test('dream nudge fires on >=3 new memories, then respects its once-guard — M3
 // The count must come from this session's own write log.
 test('dream nudge ignores concurrent sessions writes — only this session count', () => {
   const projectDir = mkdtempSync(join(tmpdir(), 'll-sn-concurrent-'));
-  const encodedPath = projectDir.replace(/[/\\]/g, '-');
+  const encodedPath = encodeProjectDir(projectDir);
   const sid = 'test-readonly-session';
 
   const r = runHook(HOOK, {
@@ -358,7 +360,7 @@ test('dream nudge ignores concurrent sessions writes — only this session count
 // plus an unrelated peer file present: count is 2, under the >=3 gate → no nudge.
 test('dream nudge counts only this session writes still present on disk', () => {
   const projectDir = mkdtempSync(join(tmpdir(), 'll-sn-presence-'));
-  const encodedPath = projectDir.replace(/[/\\]/g, '-');
+  const encodedPath = encodeProjectDir(projectDir);
   const sid = 'test-presence';
 
   const r = runHook(HOOK, {
@@ -399,7 +401,7 @@ test(
   { skip: skipOnWindows('chmod semantics: read-only dirs not enforced on win32') },
   () => {
     const projectDir = mkdtempSync(join(tmpdir(), 'll-sn-guardfail-'));
-    const encodedPath = projectDir.replace(/[/\\]/g, '-');
+    const encodedPath = encodeProjectDir(projectDir);
     const sid = 'test-guard-fail';
 
     const r = runHook(HOOK, {

--- a/tests/jsonl.test.mjs
+++ b/tests/jsonl.test.mjs
@@ -68,8 +68,18 @@ test('concurrent appends produce parseable lines (no byte interleave)', async ()
 });
 
 test('appendJsonlLineSafe returns false on unwritable path instead of throwing', () => {
-  const result = appendJsonlLineSafe('/this/path/cannot/exist/ever.jsonl', { a: 1 });
-  assert.strictEqual(result, false);
+  // A regular file used as a parent directory: mkdir/open under it fails on
+  // every platform (an absolute path under '/' is creatable on Windows, so it
+  // can't stand in for "unwritable").
+  const dir = mkdtempSync(join(tmpdir(), 'll-jsonl-'));
+  try {
+    const file = join(dir, 'not-a-dir');
+    writeFileSync(file, 'x');
+    const result = appendJsonlLineSafe(join(file, 'child.jsonl'), { a: 1 });
+    assert.strictEqual(result, false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 async function withTempDirAsync(fn) {

--- a/tests/lib-env.test.mjs
+++ b/tests/lib-env.test.mjs
@@ -1,13 +1,10 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
 
 import { isTruthy, coerceNumber, env } from '../plugin/scripts/lib/env.mjs';
 
-const MOD = JSON.stringify(
-  fileURLToPath(new URL('../plugin/scripts/lib/env.mjs', import.meta.url)),
-);
+const MOD = JSON.stringify(new URL('../plugin/scripts/lib/env.mjs', import.meta.url).href);
 
 test('isTruthy accepts canonical truthy strings', () => {
   for (const v of ['1', 'true', 'yes', 'on']) {

--- a/tests/lib-file-lock.test.mjs
+++ b/tests/lib-file-lock.test.mjs
@@ -1,17 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import {
-  mkdtempSync,
-  rmSync,
-  readFileSync,
-  writeFileSync,
-  existsSync,
-  utimesSync,
-} from 'node:fs';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync, utimesSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawn } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
 
 import { acquireLock, releaseLock, withLock } from '../plugin/scripts/lib/file-lock.mjs';
 
@@ -102,7 +94,10 @@ test('withLock releases lock when fn throws', () => {
   withTempDir((dir) => {
     const target = join(dir, 'wl-throw.json');
     assert.throws(
-      () => withLock(target, {}, () => { throw new Error('boom'); }),
+      () =>
+        withLock(target, {}, () => {
+          throw new Error('boom');
+        }),
       /boom/,
     );
     assert.equal(existsSync(target + '.lock'), false);
@@ -132,12 +127,12 @@ test('releaseLock is idempotent on null/undefined handle', () => {
 });
 
 test('cross-process race: both children terminate cleanly (mutual exclusion holds)', async () => {
-  const flockPath = fileURLToPath(new URL('../plugin/scripts/lib/file-lock.mjs', import.meta.url));
+  const flockUrl = new URL('../plugin/scripts/lib/file-lock.mjs', import.meta.url).href;
   const dir = mkdtempSync(join(tmpdir(), 'll-flock-race-'));
   try {
     const target = join(dir, 'race.json');
     const code = `
-import { acquireLock, releaseLock } from ${JSON.stringify(flockPath)};
+import { acquireLock, releaseLock } from ${JSON.stringify(flockUrl)};
 const h = acquireLock(${JSON.stringify(target)}, { retries: 2, retryDelayMs: 10 });
 if (h) {
   const buf = new Int32Array(new SharedArrayBuffer(4));
@@ -150,7 +145,9 @@ if (h) {
 `;
     const spawnChild = () =>
       new Promise((r) => {
-        const c = spawn(process.execPath, ['--input-type=module'], { stdio: ['pipe', 'pipe', 'pipe'] });
+        const c = spawn(process.execPath, ['--input-type=module'], {
+          stdio: ['pipe', 'pipe', 'pipe'],
+        });
         c.stdin.end(code);
         c.on('close', (exitCode) => r(exitCode));
       });

--- a/tests/lib-log.test.mjs
+++ b/tests/lib-log.test.mjs
@@ -1,11 +1,8 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
 
-const MOD = JSON.stringify(
-  fileURLToPath(new URL('../plugin/scripts/lib/log.mjs', import.meta.url)),
-);
+const MOD = JSON.stringify(new URL('../plugin/scripts/lib/log.mjs', import.meta.url).href);
 
 function runChild(envOverrides, code) {
   const out = spawnSync(process.execPath, ['--input-type=module', '-e', code], {
@@ -15,10 +12,13 @@ function runChild(envOverrides, code) {
 }
 
 test('logError always writes a parseable JSON line to stderr', () => {
-  const { stderr, status } = runChild({}, `
+  const { stderr, status } = runChild(
+    {},
+    `
     const m = await import(${MOD});
     m.logError('test-scope', new Error('boom'), { k: 'v' });
-  `);
+  `,
+  );
   assert.equal(status, 0);
   const lines = stderr.trim().split('\n').filter(Boolean);
   assert.equal(lines.length, 1);
@@ -31,38 +31,50 @@ test('logError always writes a parseable JSON line to stderr', () => {
 });
 
 test('logError accepts a string instead of an Error', () => {
-  const { stderr } = runChild({}, `
+  const { stderr } = runChild(
+    {},
+    `
     const m = await import(${MOD});
     m.logError('s', 'just a string');
-  `);
+  `,
+  );
   const parsed = JSON.parse(stderr.trim().split('\n').filter(Boolean)[0]);
   assert.equal(parsed.msg, 'just a string');
   assert.equal(parsed.level, 'error');
 });
 
 test('logError includes custom meta fields', () => {
-  const { stderr } = runChild({}, `
+  const { stderr } = runChild(
+    {},
+    `
     const m = await import(${MOD});
     m.logError('s', new Error('x'), { requestId: 'abc' });
-  `);
+  `,
+  );
   const parsed = JSON.parse(stderr.trim().split('\n').filter(Boolean)[0]);
   assert.equal(parsed.meta.requestId, 'abc');
 });
 
 test('debug is silent without LL_HOOK_DEBUG', () => {
-  const { stderr } = runChild({ LL_HOOK_DEBUG: undefined }, `
+  const { stderr } = runChild(
+    { LL_HOOK_DEBUG: undefined },
+    `
     delete process.env.LL_HOOK_DEBUG;
     const m = await import(${MOD});
     m.debug('s', 'should not appear');
-  `);
+  `,
+  );
   assert.equal(stderr.trim(), '');
 });
 
 test('debug emits when LL_HOOK_DEBUG=1', () => {
-  const { stderr, status } = runChild({ LL_HOOK_DEBUG: '1' }, `
+  const { stderr, status } = runChild(
+    { LL_HOOK_DEBUG: '1' },
+    `
     const m = await import(${MOD});
     m.debug('s', 'hello debug');
-  `);
+  `,
+  );
   assert.equal(status, 0);
   const parsed = JSON.parse(stderr.trim().split('\n').filter(Boolean)[0]);
   assert.equal(parsed.level, 'debug');
@@ -70,21 +82,27 @@ test('debug emits when LL_HOOK_DEBUG=1', () => {
 });
 
 test('info emits unconditionally regardless of LL_HOOK_DEBUG', () => {
-  const { stderr } = runChild({ LL_HOOK_DEBUG: undefined }, `
+  const { stderr } = runChild(
+    { LL_HOOK_DEBUG: undefined },
+    `
     delete process.env.LL_HOOK_DEBUG;
     const m = await import(${MOD});
     m.info('s', 'always visible');
-  `);
+  `,
+  );
   const parsed = JSON.parse(stderr.trim().split('\n').filter(Boolean)[0]);
   assert.equal(parsed.level, 'info');
   assert.equal(parsed.msg, 'always visible');
 });
 
 test('log lines include ts, plugin, scope, msg fields', () => {
-  const { stderr } = runChild({}, `
+  const { stderr } = runChild(
+    {},
+    `
     const m = await import(${MOD});
     m.info('my-scope', 'a message');
-  `);
+  `,
+  );
   const parsed = JSON.parse(stderr.trim().split('\n').filter(Boolean)[0]);
   assert.ok(parsed.ts, 'ts must be present');
   assert.ok(parsed.plugin, 'plugin must be present');
@@ -93,23 +111,29 @@ test('log lines include ts, plugin, scope, msg fields', () => {
 });
 
 test('logError never throws even with circular meta', () => {
-  const { stdout, status } = runChild({}, `
+  const { stdout, status } = runChild(
+    {},
+    `
     const m = await import(${MOD});
     const circ = {}; circ.self = circ;
     m.logError('s', new Error('x'), circ);
     console.log('survived');
-  `);
+  `,
+  );
   assert.equal(status, 0);
   assert.ok(stdout.includes('survived'), 'logError must not throw on circular meta');
 });
 
 test('logError with Error preserves err.code when set', () => {
-  const { stderr } = runChild({}, `
+  const { stderr } = runChild(
+    {},
+    `
     const m = await import(${MOD});
     const e = new Error('code test');
     e.code = 'ENOENT';
     m.logError('s', e);
-  `);
+  `,
+  );
   const parsed = JSON.parse(stderr.trim().split('\n').filter(Boolean)[0]);
   assert.equal(parsed.meta.err.code, 'ENOENT');
 });

--- a/tests/lib-plugin-meta.test.mjs
+++ b/tests/lib-plugin-meta.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { join } from 'node:path';
+import { join, isAbsolute, basename } from 'node:path';
 import { spawnSync } from 'node:child_process';
 
 import {
@@ -14,13 +14,13 @@ import {
 const MOD = JSON.stringify(new URL('../plugin/scripts/lib/plugin-meta.mjs', import.meta.url).href);
 
 test('pluginRoot resolves to the plugin root', () => {
-  const root = pluginRoot();
+  const root = pluginRoot().replace(/\\/g, '/');
   // Should end with /learning-loop/plugin (direct checkout or worktree under .worktrees/ or .claude/worktrees/).
   assert.match(root, /learning-loop(\/(\.claude\/)?\.?worktrees\/[^/]+)?\/plugin$/);
 });
 
 test('pluginRoot is an absolute path', () => {
-  assert.ok(pluginRoot().startsWith('/'));
+  assert.ok(isAbsolute(pluginRoot()));
 });
 
 test('pluginVersion reads version from .claude-plugin/plugin.json', () => {
@@ -64,7 +64,10 @@ test('dataDir defaults to ~/.claude/plugins/data/learning-loop (subprocess)', ()
     { env: { ...process.env, CLAUDE_PLUGIN_DATA: undefined } },
   );
   assert.equal(out.status, 0, out.stderr.toString());
-  assert.match(out.stdout.toString().trim(), /\.claude\/plugins\/data\/learning-loop$/);
+  assert.match(
+    out.stdout.toString().trim().replace(/\\/g, '/'),
+    /\.claude\/plugins\/data\/learning-loop$/,
+  );
 });
 
 test('cacheDir is dataDir + /cache', () => {
@@ -80,6 +83,6 @@ test('cacheDir is dataDir + /cache', () => {
 test('cacheDir ends with /cache', () => {
   const c = cacheDir();
   if (c !== null) {
-    assert.ok(c.endsWith('/cache'));
+    assert.equal(basename(c), 'cache');
   }
 });

--- a/tests/lib-plugin-meta.test.mjs
+++ b/tests/lib-plugin-meta.test.mjs
@@ -2,7 +2,6 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
 
 import {
   pluginRoot,
@@ -12,9 +11,7 @@ import {
   cacheDir,
 } from '../plugin/scripts/lib/plugin-meta.mjs';
 
-const MOD = JSON.stringify(
-  fileURLToPath(new URL('../plugin/scripts/lib/plugin-meta.mjs', import.meta.url)),
-);
+const MOD = JSON.stringify(new URL('../plugin/scripts/lib/plugin-meta.mjs', import.meta.url).href);
 
 test('pluginRoot resolves to the plugin root', () => {
   const root = pluginRoot();
@@ -39,10 +36,14 @@ test('pluginId formats as name@version', () => {
 test('dataDir honours CLAUDE_PLUGIN_DATA env var (subprocess)', () => {
   const out = spawnSync(
     process.execPath,
-    ['--input-type=module', '-e', `
+    [
+      '--input-type=module',
+      '-e',
+      `
       const m = await import(${MOD});
       console.log(m.dataDir());
-    `],
+    `,
+    ],
     { env: { ...process.env, CLAUDE_PLUGIN_DATA: '/tmp/llcustom' } },
   );
   assert.equal(out.status, 0, out.stderr.toString());
@@ -52,10 +53,14 @@ test('dataDir honours CLAUDE_PLUGIN_DATA env var (subprocess)', () => {
 test('dataDir defaults to ~/.claude/plugins/data/learning-loop (subprocess)', () => {
   const out = spawnSync(
     process.execPath,
-    ['--input-type=module', '-e', `
+    [
+      '--input-type=module',
+      '-e',
+      `
       const m = await import(${MOD});
       console.log(m.dataDir());
-    `],
+    `,
+    ],
     { env: { ...process.env, CLAUDE_PLUGIN_DATA: undefined } },
   );
   assert.equal(out.status, 0, out.stderr.toString());

--- a/tests/librarian-verify-route-skill-parity.test.mjs
+++ b/tests/librarian-verify-route-skill-parity.test.mjs
@@ -1,13 +1,14 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
 // The Verify router lives inline in skills/research/SKILL.md (the Workflow sandbox
 // can't import a module). verify-route.mjs is the tested source of truth; this test
 // extracts the inline copies from SKILL.md and asserts they behave identically, so the
 // two can't silently drift.
 
-const SKILL = new URL('../plugin/skills/research/SKILL.md', import.meta.url).pathname;
+const SKILL = fileURLToPath(new URL('../plugin/skills/research/SKILL.md', import.meta.url));
 const md = readFileSync(SKILL, 'utf8');
 
 function extractFn(name) {

--- a/tests/librarian-verify-source.test.mjs
+++ b/tests/librarian-verify-source.test.mjs
@@ -2,8 +2,11 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
 import { verifyClaimSource } from '../plugin/scripts/librarian/verify-source.mjs';
+import { fileURLToPath } from 'node:url';
 
-const CLI = new URL('../plugin/scripts/librarian/verify-source.mjs', import.meta.url).pathname;
+const CLI = fileURLToPath(
+  new URL('../plugin/scripts/librarian/verify-source.mjs', import.meta.url),
+);
 
 const claim = { claim: 'c', quote: 'q', url: 'u' };
 const deps = (over = {}) => ({

--- a/tests/marker-cli.test.mjs
+++ b/tests/marker-cli.test.mjs
@@ -7,11 +7,20 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, mkdirSync, utimesSync } from 'node:fs';
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  utimesSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const CLI = new URL('../plugin/scripts/marker.mjs', import.meta.url).pathname;
+const CLI = fileURLToPath(new URL('../plugin/scripts/marker.mjs', import.meta.url));
 
 function run(args, pluginData) {
   return spawnSync(process.execPath, [CLI, ...args], {
@@ -57,7 +66,11 @@ test('stamp last-dream clears a stale dream-gate nudge so the next session does 
     const r = run(['stamp', 'last-dream'], pd);
     assert.equal(r.status, 0, r.stderr);
     const gate = JSON.parse(readFileSync(gatePath, 'utf8'));
-    assert.equal(gate.nudge, null, 'dream-gate cache must read {nudge: null} after a successful stamp');
+    assert.equal(
+      gate.nudge,
+      null,
+      'dream-gate cache must read {nudge: null} after a successful stamp',
+    );
   } finally {
     rmSync(pd, { recursive: true, force: true });
   }

--- a/tests/marker-pairs.test.mjs
+++ b/tests/marker-pairs.test.mjs
@@ -11,9 +11,10 @@ import { spawnSync } from 'node:child_process';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const CLI = new URL('../plugin/scripts/marker.mjs', import.meta.url).pathname;
-const STOP_HOOK = new URL('../plugin/hooks/stop-nudge.js', import.meta.url).pathname;
+const CLI = fileURLToPath(new URL('../plugin/scripts/marker.mjs', import.meta.url));
+const STOP_HOOK = fileURLToPath(new URL('../plugin/hooks/stop-nudge.js', import.meta.url));
 
 test('last-reflect stamped under one $TMPDIR suppresses stop-nudge under another', () => {
   const pd = mkdtempSync(join(tmpdir(), 'll-pair-pd-'));
@@ -30,7 +31,11 @@ test('last-reflect stamped under one $TMPDIR suppresses stop-nudge under another
 
     const r = spawnSync(process.execPath, [STOP_HOOK], {
       encoding: 'utf8',
-      input: JSON.stringify({ session_id: 'pair-test', transcript_path: transcript, stop_hook_active: false }),
+      input: JSON.stringify({
+        session_id: 'pair-test',
+        transcript_path: transcript,
+        stop_hook_active: false,
+      }),
       env: {
         PATH: process.env.PATH,
         CLAUDE_PLUGIN_DATA: pd,

--- a/tests/memory-paths.test.mjs
+++ b/tests/memory-paths.test.mjs
@@ -1,49 +1,53 @@
-import test from "node:test";
-import assert from "node:assert/strict";
-import { mkdirSync, writeFileSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { randomBytes } from "node:crypto";
-import { listMemoryFiles, resolveMemoryDir } from "../plugin/scripts/lib/memory-paths.mjs";
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomBytes } from 'node:crypto';
+import { listMemoryFiles, resolveMemoryDir } from '../plugin/scripts/lib/memory-paths.mjs';
 
-test("resolveMemoryDir encodes the project dir like dream-gate does", () => {
-  const dir = resolveMemoryDir("/Users/robin/brain", "/home/x");
-  assert.equal(dir, "/home/x/.claude/projects/-Users-robin-brain/memory");
+test('resolveMemoryDir encodes the project dir like dream-gate does', () => {
+  const dir = resolveMemoryDir('/Users/robin/brain', '/home/x');
+  assert.equal(dir, join('/home/x', '.claude', 'projects', '-Users-robin-brain', 'memory'));
 });
 
-test("resolveMemoryDir returns null when project dir is absent", () => {
-  assert.equal(resolveMemoryDir(undefined, "/home/x"), null);
+test('resolveMemoryDir returns null when project dir is absent', () => {
+  assert.equal(resolveMemoryDir(undefined, '/home/x'), null);
 });
 
-test("listMemoryFiles returns .md files in a memory dir, excludes MEMORY.md and subdirs", () => {
-  const root = join(tmpdir(), `ll-mem-${randomBytes(8).toString("hex")}`);
-  const memDir = join(root, "memory");
-  mkdirSync(join(memDir, "_archived"), { recursive: true });
-  writeFileSync(join(memDir, "feedback_a.md"), "x");
-  writeFileSync(join(memDir, "project_b.md"), "x");
-  writeFileSync(join(memDir, "MEMORY.md"), "index");
-  writeFileSync(join(memDir, "_dream_log.md"), "log");
-  writeFileSync(join(memDir, "_archived", "old.md"), "x");
+test('listMemoryFiles returns .md files in a memory dir, excludes MEMORY.md and subdirs', () => {
+  const root = join(tmpdir(), `ll-mem-${randomBytes(8).toString('hex')}`);
+  const memDir = join(root, 'memory');
+  mkdirSync(join(memDir, '_archived'), { recursive: true });
+  writeFileSync(join(memDir, 'feedback_a.md'), 'x');
+  writeFileSync(join(memDir, 'project_b.md'), 'x');
+  writeFileSync(join(memDir, 'MEMORY.md'), 'index');
+  writeFileSync(join(memDir, '_dream_log.md'), 'log');
+  writeFileSync(join(memDir, '_archived', 'old.md'), 'x');
 
-  const files = listMemoryFiles(memDir).map((f) => f.name).sort();
+  const files = listMemoryFiles(memDir)
+    .map((f) => f.name)
+    .sort();
   rmSync(root, { recursive: true, force: true });
 
-  assert.deepEqual(files, ["feedback_a.md", "project_b.md"]);
+  assert.deepEqual(files, ['feedback_a.md', 'project_b.md']);
 });
 
-test("listMemoryFiles excludes dotfiles, as its docstring promises", () => {
+test('listMemoryFiles excludes dotfiles, as its docstring promises', () => {
   // A `.env.backup.md` ends in .md and isn't underscore-prefixed, so it used to
   // slip through into seed bundles (which only require type: feedback). The
   // docstring claims dotfiles are excluded; enforce that so the gate stays closed.
-  const root = join(tmpdir(), `ll-mem-dot-${randomBytes(8).toString("hex")}`);
-  const memDir = join(root, "memory");
+  const root = join(tmpdir(), `ll-mem-dot-${randomBytes(8).toString('hex')}`);
+  const memDir = join(root, 'memory');
   mkdirSync(memDir, { recursive: true });
-  writeFileSync(join(memDir, "feedback_a.md"), "x");
-  writeFileSync(join(memDir, ".env.backup.md"), "secret");
-  writeFileSync(join(memDir, ".hidden.md"), "x");
+  writeFileSync(join(memDir, 'feedback_a.md'), 'x');
+  writeFileSync(join(memDir, '.env.backup.md'), 'secret');
+  writeFileSync(join(memDir, '.hidden.md'), 'x');
 
-  const files = listMemoryFiles(memDir).map((f) => f.name).sort();
+  const files = listMemoryFiles(memDir)
+    .map((f) => f.name)
+    .sort();
   rmSync(root, { recursive: true, force: true });
 
-  assert.deepEqual(files, ["feedback_a.md"]);
+  assert.deepEqual(files, ['feedback_a.md']);
 });

--- a/tests/paths-data-files.test.mjs
+++ b/tests/paths-data-files.test.mjs
@@ -1,9 +1,10 @@
-import test from "node:test";
-import assert from "node:assert/strict";
-import { DATA_FILES } from "../plugin/scripts/lib/paths.mjs";
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { join } from 'node:path';
+import { DATA_FILES } from '../plugin/scripts/lib/paths.mjs';
 
-test("harvest denylist + dedup log anchor under plugin-data", () => {
-  const pd = "/tmp/pd";
-  assert.equal(DATA_FILES.harvestDenylist(pd), "/tmp/pd/.harvest-denylist");
-  assert.equal(DATA_FILES.harvestedLog(pd), "/tmp/pd/.harvested-log");
+test('harvest denylist + dedup log anchor under plugin-data', () => {
+  const pd = join('/tmp', 'pd');
+  assert.equal(DATA_FILES.harvestDenylist(pd), join(pd, '.harvest-denylist'));
+  assert.equal(DATA_FILES.harvestedLog(pd), join(pd, '.harvested-log'));
 });

--- a/tests/pre-write-check-duplicate-gate.test.mjs
+++ b/tests/pre-write-check-duplicate-gate.test.mjs
@@ -6,6 +6,7 @@
 
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
 import {
   mkdirSync,
   writeFileSync,
@@ -25,8 +26,8 @@ import { VAULT_DIRS, TITLE_INDEX_EXTRA_DIRS } from '../plugin/hooks/lib/snapshot
 import { HookConfig } from '../plugin/scripts/lib/hook-config.mjs';
 import { DUPLICATE_GATE_STALE_DAEMON_CODE } from '../plugin/hooks/pre-write-check.js';
 
-const HOOK = new URL('../plugin/hooks/pre-write-check.js', import.meta.url).pathname;
-const UDS_SERVER = new URL('./helpers/uds-reflect-server.mjs', import.meta.url).pathname;
+const HOOK = fileURLToPath(new URL('../plugin/hooks/pre-write-check.js', import.meta.url));
+const UDS_SERVER = fileURLToPath(new URL('./helpers/uds-reflect-server.mjs', import.meta.url));
 
 const SKIP = skipOnWindows('UDS socket: filesystem sockets not supported on win32');
 let VAULT;

--- a/tests/pre-write-check.test.mjs
+++ b/tests/pre-write-check.test.mjs
@@ -5,8 +5,9 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { runHook } from './helpers/hook-runner.mjs';
 import { VAULT_DIRS, TITLE_INDEX_EXTRA_DIRS } from '../plugin/hooks/lib/snapshot.mjs';
+import { fileURLToPath } from 'node:url';
 
-const HOOK = new URL('../plugin/hooks/pre-write-check.js', import.meta.url).pathname;
+const HOOK = fileURLToPath(new URL('../plugin/hooks/pre-write-check.js', import.meta.url));
 let VAULT;
 let NON_VAULT;
 

--- a/tests/redact-scan.test.mjs
+++ b/tests/redact-scan.test.mjs
@@ -5,9 +5,10 @@ import { writeFileSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomBytes } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
 import { scanForSecrets } from '../plugin/scripts/redact-scan.mjs';
 
-const SCRIPT = new URL('../plugin/scripts/redact-scan.mjs', import.meta.url).pathname;
+const SCRIPT = fileURLToPath(new URL('../plugin/scripts/redact-scan.mjs', import.meta.url));
 
 test('flags known credential prefixes (github-pat)', () => {
   const hits = scanForSecrets('token=ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789 done');

--- a/tests/retrieval-usage.test.mjs
+++ b/tests/retrieval-usage.test.mjs
@@ -3,13 +3,13 @@ import assert from 'node:assert';
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { spawnSync } from 'node:child_process';
 
 const SCRIPTS = join(dirname(fileURLToPath(import.meta.url)), '..', 'plugin', 'scripts');
 const REPORT = join(SCRIPTS, 'retrieval-report.mjs');
 const { sessionSurfaced, usageReport, loadNoteUsageEvents } = await import(
-  join(SCRIPTS, 'lib', 'retrieval-usage.mjs')
+  pathToFileURL(join(SCRIPTS, 'lib', 'retrieval-usage.mjs')).href
 );
 
 const NOW = new Date('2026-06-12T00:00:00Z').getTime();

--- a/tests/seed-select-cli.test.mjs
+++ b/tests/seed-select-cli.test.mjs
@@ -9,8 +9,9 @@ import { execFileSync } from 'node:child_process';
 import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
 
-const CLI = new URL('../plugin/scripts/seed-select.mjs', import.meta.url).pathname;
+const CLI = fileURLToPath(new URL('../plugin/scripts/seed-select.mjs', import.meta.url));
 let memDir;
 
 function runCli(args) {
@@ -47,7 +48,11 @@ test('defaults to type=feedback when no types arg is given', () => {
 
 test('comma-split types arg widens the selection', () => {
   const { kept } = runCli([memDir, 'feedback,project']);
-  assert.deepEqual(kept.sort(), ['feedback_acme_notes.md', 'feedback_clean.md', 'project_thing.md']);
+  assert.deepEqual(kept.sort(), [
+    'feedback_acme_notes.md',
+    'feedback_clean.md',
+    'project_thing.md',
+  ]);
 });
 
 test('comma-split deny arg drops on word-boundary name match', () => {
@@ -59,7 +64,11 @@ test('comma-split deny arg drops on word-boundary name match', () => {
 
 test('whitespace around commas is tolerated', () => {
   const { kept } = runCli([memDir, ' feedback , project ']);
-  assert.deepEqual(kept.sort(), ['feedback_acme_notes.md', 'feedback_clean.md', 'project_thing.md']);
+  assert.deepEqual(kept.sort(), [
+    'feedback_acme_notes.md',
+    'feedback_clean.md',
+    'project_thing.md',
+  ]);
 });
 
 test('missing memDir exits 2 with usage on stderr', () => {

--- a/tests/session-label.test.mjs
+++ b/tests/session-label.test.mjs
@@ -5,6 +5,7 @@ import { writeFileSync, readFileSync, rmSync, mkdirSync, mkdtempSync, existsSync
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomUUID } from 'node:crypto';
+import { skipOnWindows } from './helpers/platform.mjs';
 
 const HOOK = join(import.meta.dirname, '..', 'plugin', 'hooks', 'session-label.js');
 // mkdtemp, not a fixed name: parallel test runs sharing one dir flake when
@@ -319,115 +320,50 @@ describe('session-label stdout contract', () => {
   });
 });
 
-describe('session-label dedupe levels across prompts', () => {
-  // Regression: a note surfaced only as a one-line "Related notes" POINTER on
-  // prompt 1 must still get its BODY injected when it is the best match on
-  // prompt 2. Pre-fix, pointer paths were persisted into the dedupe state
-  // indistinguishably from body-injected paths and filtered out wholesale for
-  // the whole DEDUPE_WINDOW_MS.
-  it('pointer-only note from prompt 1 is body-injected on prompt 2', () => {
-    const base = mkdtempSync(join(tmpdir(), 'll-live-dedupe-'));
-    try {
-      const vault = join(base, 'vault');
-      const pluginData = join(base, 'plugin-data');
-      const home = join(base, 'home');
-      const stubBin = join(pluginData, 'bin');
-      mkdirSync(join(vault, 'notes'), { recursive: true });
-      mkdirSync(home, { recursive: true });
-      mkdirSync(stubBin, { recursive: true });
+describe(
+  'session-label dedupe levels across prompts',
+  {
+    skip: skipOnWindows(
+      'shebang stub: #!/bin/sh ll-search stub is not an executable ll-search.exe on win32',
+    ),
+  },
+  () => {
+    // Regression: a note surfaced only as a one-line "Related notes" POINTER on
+    // prompt 1 must still get its BODY injected when it is the best match on
+    // prompt 2. Pre-fix, pointer paths were persisted into the dedupe state
+    // indistinguishably from body-injected paths and filtered out wholesale for
+    // the whole DEDUPE_WINDOW_MS.
+    it('pointer-only note from prompt 1 is body-injected on prompt 2', () => {
+      const base = mkdtempSync(join(tmpdir(), 'll-live-dedupe-'));
+      try {
+        const vault = join(base, 'vault');
+        const pluginData = join(base, 'plugin-data');
+        const home = join(base, 'home');
+        const stubBin = join(pluginData, 'bin');
+        mkdirSync(join(vault, 'notes'), { recursive: true });
+        mkdirSync(home, { recursive: true });
+        mkdirSync(stubBin, { recursive: true });
 
-      writeFileSync(
-        join(vault, 'notes', 'alpha.md'),
-        'Alpha note body about hook injection ordering and budgets.\n',
-      );
-      writeFileSync(
-        join(vault, 'notes', 'beta.md'),
-        'Beta note body about dedupe windows and pointer suppression.\n',
-      );
+        writeFileSync(
+          join(vault, 'notes', 'alpha.md'),
+          'Alpha note body about hook injection ordering and budgets.\n',
+        );
+        writeFileSync(
+          join(vault, 'notes', 'beta.md'),
+          'Beta note body about dedupe windows and pointer suppression.\n',
+        );
 
-      // Stub returns the same two above-threshold hits on both prompts.
-      const hits = JSON.stringify([
-        { path: 'notes/alpha.md', title: 'alpha', score: 0.99 },
-        { path: 'notes/beta.md', title: 'beta', score: 0.9 },
-      ]);
-      writeFileSync(join(stubBin, 'll-search'), `#!/bin/sh\nprintf '%s' '${hits}'\n`, {
-        mode: 0o755,
-      });
-
-      const sid = randomUUID();
-      const env = {
-        ...process.env,
-        HOME: home,
-        TMPDIR: base,
-        CLAUDE_PLUGIN_DATA: pluginData,
-        VAULT_PATH: vault,
-        LEARNING_LOOP_INJECTION_MODE: 'live',
-        LEARNING_LOOP_INJECTION_THRESHOLD: '0.1',
-        LEARNING_LOOP_INJECTION_RACE_CAP_MS: '20000',
-      };
-      const runPrompt = (prompt) =>
-        execFileSync('node', [HOOK], {
-          input: JSON.stringify({ session_id: sid, prompt, transcript_path: '', cwd: '/tmp' }),
-          encoding: 'utf-8',
-          timeout: 30000,
-          env,
+        // Stub returns the same two above-threshold hits on both prompts.
+        const hits = JSON.stringify([
+          { path: 'notes/alpha.md', title: 'alpha', score: 0.99 },
+          { path: 'notes/beta.md', title: 'beta', score: 0.9 },
+        ]);
+        writeFileSync(join(stubBin, 'll-search'), `#!/bin/sh\nprintf '%s' '${hits}'\n`, {
+          mode: 0o755,
         });
 
-      const out1 = runPrompt('tell me about hook injection ordering and budgets');
-      assert.ok(out1.includes('Alpha note body'), 'prompt 1 must body-inject the top hit');
-      assert.ok(out1.includes('notes/beta.md'), 'prompt 1 must list beta as a pointer');
-      assert.ok(!out1.includes('Beta note body'), 'prompt 1 must not inject the pointer body');
-
-      const out2 = runPrompt('now drill into dedupe windows and pointer suppression');
-      assert.ok(
-        out2.includes('Beta note body'),
-        `pointer-seen note must be body-injected on the follow-up prompt; got: ${out2}`,
-      );
-    } finally {
-      rmSync(base, { recursive: true, force: true });
-    }
-  });
-});
-
-describe('session-label live injection scrubbing', () => {
-  it('live mode scrubs secrets from injected context (parity with shadow)', () => {
-    const base = mkdtempSync(join(tmpdir(), 'll-live-scrub-'));
-    try {
-      const vault = join(base, 'vault');
-      const pluginData = join(base, 'plugin-data');
-      const home = join(base, 'home');
-      const stubBin = join(pluginData, 'bin');
-      mkdirSync(join(vault, 'notes'), { recursive: true });
-      mkdirSync(home, { recursive: true });
-      mkdirSync(stubBin, { recursive: true });
-
-      writeFileSync(
-        join(vault, 'notes', 'aws-key-rotation.md'),
-        'The deploy key AKIAIOSFODNN7EXAMPLE must be rotated quarterly. Keep the rotation runbook current.\n',
-      );
-
-      // Stub ll-search in <pluginData>/bin — findBinary()'s first slot, so it
-      // beats a locally built native/target/release binary and any PATH entry.
-      // It emits one above-threshold hit without a body, so the hook enriches
-      // it by reading the vault note (which holds the secret).
-      const hit = JSON.stringify([
-        { path: 'notes/aws-key-rotation.md', title: 'aws-key-rotation', score: 0.99 },
-      ]);
-      writeFileSync(join(stubBin, 'll-search'), `#!/bin/sh\nprintf '%s' '${hit}'\n`, {
-        mode: 0o755,
-      });
-
-      const input = JSON.stringify({
-        session_id: randomUUID(),
-        prompt: 'how should we rotate the AWS deploy key for the worker',
-        transcript_path: '',
-        cwd: '/tmp',
-      });
-      const out = execFileSync('node', [HOOK], {
-        input,
-        encoding: 'utf-8',
-        timeout: 30000,
-        env: {
+        const sid = randomUUID();
+        const env = {
           ...process.env,
           HOME: home,
           TMPDIR: base,
@@ -435,20 +371,101 @@ describe('session-label live injection scrubbing', () => {
           VAULT_PATH: vault,
           LEARNING_LOOP_INJECTION_MODE: 'live',
           LEARNING_LOOP_INJECTION_THRESHOLD: '0.1',
-          // Generous race cap: under full-suite load the 1500ms default can
-          // abort the stub backend before it answers, failing the gate.
           LEARNING_LOOP_INJECTION_RACE_CAP_MS: '20000',
-        },
-      });
+        };
+        const runPrompt = (prompt) =>
+          execFileSync('node', [HOOK], {
+            input: JSON.stringify({ session_id: sid, prompt, transcript_path: '', cwd: '/tmp' }),
+            encoding: 'utf-8',
+            timeout: 30000,
+            env,
+          });
 
-      assert.ok(
-        out.length > 0,
-        'gate did not pass — stub arrangement broken, fix before judging the scrub',
-      );
-      assert.ok(!out.includes('AKIAIOSFODNN7EXAMPLE'), 'AWS key leaked into live injection');
-      assert.ok(out.includes('[REDACTED]'));
-    } finally {
-      rmSync(base, { recursive: true, force: true });
-    }
-  });
-});
+        const out1 = runPrompt('tell me about hook injection ordering and budgets');
+        assert.ok(out1.includes('Alpha note body'), 'prompt 1 must body-inject the top hit');
+        assert.ok(out1.includes('notes/beta.md'), 'prompt 1 must list beta as a pointer');
+        assert.ok(!out1.includes('Beta note body'), 'prompt 1 must not inject the pointer body');
+
+        const out2 = runPrompt('now drill into dedupe windows and pointer suppression');
+        assert.ok(
+          out2.includes('Beta note body'),
+          `pointer-seen note must be body-injected on the follow-up prompt; got: ${out2}`,
+        );
+      } finally {
+        rmSync(base, { recursive: true, force: true });
+      }
+    });
+  },
+);
+
+describe(
+  'session-label live injection scrubbing',
+  {
+    skip: skipOnWindows(
+      'shebang stub: #!/bin/sh ll-search stub is not an executable ll-search.exe on win32',
+    ),
+  },
+  () => {
+    it('live mode scrubs secrets from injected context (parity with shadow)', () => {
+      const base = mkdtempSync(join(tmpdir(), 'll-live-scrub-'));
+      try {
+        const vault = join(base, 'vault');
+        const pluginData = join(base, 'plugin-data');
+        const home = join(base, 'home');
+        const stubBin = join(pluginData, 'bin');
+        mkdirSync(join(vault, 'notes'), { recursive: true });
+        mkdirSync(home, { recursive: true });
+        mkdirSync(stubBin, { recursive: true });
+
+        writeFileSync(
+          join(vault, 'notes', 'aws-key-rotation.md'),
+          'The deploy key AKIAIOSFODNN7EXAMPLE must be rotated quarterly. Keep the rotation runbook current.\n',
+        );
+
+        // Stub ll-search in <pluginData>/bin — findBinary()'s first slot, so it
+        // beats a locally built native/target/release binary and any PATH entry.
+        // It emits one above-threshold hit without a body, so the hook enriches
+        // it by reading the vault note (which holds the secret).
+        const hit = JSON.stringify([
+          { path: 'notes/aws-key-rotation.md', title: 'aws-key-rotation', score: 0.99 },
+        ]);
+        writeFileSync(join(stubBin, 'll-search'), `#!/bin/sh\nprintf '%s' '${hit}'\n`, {
+          mode: 0o755,
+        });
+
+        const input = JSON.stringify({
+          session_id: randomUUID(),
+          prompt: 'how should we rotate the AWS deploy key for the worker',
+          transcript_path: '',
+          cwd: '/tmp',
+        });
+        const out = execFileSync('node', [HOOK], {
+          input,
+          encoding: 'utf-8',
+          timeout: 30000,
+          env: {
+            ...process.env,
+            HOME: home,
+            TMPDIR: base,
+            CLAUDE_PLUGIN_DATA: pluginData,
+            VAULT_PATH: vault,
+            LEARNING_LOOP_INJECTION_MODE: 'live',
+            LEARNING_LOOP_INJECTION_THRESHOLD: '0.1',
+            // Generous race cap: under full-suite load the 1500ms default can
+            // abort the stub backend before it answers, failing the gate.
+            LEARNING_LOOP_INJECTION_RACE_CAP_MS: '20000',
+          },
+        });
+
+        assert.ok(
+          out.length > 0,
+          'gate did not pass — stub arrangement broken, fix before judging the scrub',
+        );
+        assert.ok(!out.includes('AKIAIOSFODNN7EXAMPLE'), 'AWS key leaked into live injection');
+        assert.ok(out.includes('[REDACTED]'));
+      } finally {
+        rmSync(base, { recursive: true, force: true });
+      }
+    });
+  },
+);

--- a/tests/snapshot-race.test.mjs
+++ b/tests/snapshot-race.test.mjs
@@ -4,7 +4,6 @@ import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'nod
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { spawn } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
 
 const tmpPluginData = mkdtempSync(join(tmpdir(), 'll-snap-race-pd-'));
 const tmpVault = mkdtempSync(join(tmpdir(), 'll-snap-race-vault-'));
@@ -15,7 +14,7 @@ mkdirSync(join(tmpVault, '0-inbox'), { recursive: true });
 writeFileSync(join(tmpVault, '0-inbox', 'seed.md'), 'seed\n');
 
 const snapshotPath = join(tmpPluginData, 'vault-snapshot.json');
-const snapshotMjsPath = fileURLToPath(new URL('../plugin/hooks/lib/snapshot.mjs', import.meta.url));
+const snapshotMjsUrl = new URL('../plugin/hooks/lib/snapshot.mjs', import.meta.url).href;
 
 const mod = await import('../plugin/hooks/lib/snapshot.mjs');
 const { rebuildVaultSnapshot } = mod;
@@ -25,7 +24,7 @@ rebuildVaultSnapshot(tmpVault);
 function runWorker(relPath) {
   return new Promise((resolve, reject) => {
     const code = `
-import { loadVaultSnapshot, maybeSplice } from ${JSON.stringify(snapshotMjsPath)};
+import { loadVaultSnapshot, maybeSplice } from ${JSON.stringify(snapshotMjsUrl)};
 const snap = loadVaultSnapshot(${JSON.stringify(tmpVault)});
 maybeSplice(snap, {
   folder: '0-inbox',

--- a/tests/update-check-worker.test.mjs
+++ b/tests/update-check-worker.test.mjs
@@ -12,11 +12,11 @@ import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createServer } from 'node:http';
+import { fileURLToPath } from 'node:url';
 
-const WORKER = new URL(
-  '../plugin/hooks/session-start/update-check-worker.mjs',
-  import.meta.url,
-).pathname;
+const WORKER = fileURLToPath(
+  new URL('../plugin/hooks/session-start/update-check-worker.mjs', import.meta.url),
+);
 
 function runWorkerSync(cacheFile, installed, apiUrl, timeoutMs) {
   const args = [WORKER, cacheFile, installed, apiUrl];

--- a/tests/vault-search-session-start-refresh.test.mjs
+++ b/tests/vault-search-session-start-refresh.test.mjs
@@ -5,6 +5,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import {
   mkdtempSync,
   mkdirSync,
@@ -18,7 +19,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { skipOnWindows } from './helpers/platform.mjs';
 
-const VAULT_SEARCH = new URL('../plugin/scripts/vault-search.mjs', import.meta.url).pathname;
+const VAULT_SEARCH = fileURLToPath(new URL('../plugin/scripts/vault-search.mjs', import.meta.url));
 
 // Create a minimal stub ll-search binary that emits an empty JSON array and
 // exits 0. Without a discoverable binary, vault-search.mjs exits early (code 2)

--- a/tests/vault-walk.test.mjs
+++ b/tests/vault-walk.test.mjs
@@ -1,24 +1,26 @@
-import test from "node:test";
-import assert from "node:assert/strict";
-import { mkdirSync, writeFileSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { randomBytes } from "node:crypto";
-import { listVaultNotes } from "../plugin/scripts/lib/vault-walk.mjs";
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomBytes } from 'node:crypto';
+import { listVaultNotes } from '../plugin/scripts/lib/vault-walk.mjs';
 
-test("walks .md recursively, excludes _archive/_archived/Excalidraw and dotdirs", () => {
-  const v = join(tmpdir(), `ll-vault-${randomBytes(8).toString("hex")}`);
-  mkdirSync(join(v, "3-permanent"), { recursive: true });
-  mkdirSync(join(v, "_archive"), { recursive: true });
-  mkdirSync(join(v, "Excalidraw"), { recursive: true });
-  mkdirSync(join(v, ".obsidian"), { recursive: true });
-  writeFileSync(join(v, "3-permanent", "a.md"), "x");
-  writeFileSync(join(v, "_archive", "old.md"), "x");
-  writeFileSync(join(v, "Excalidraw", "d.excalidraw.md"), "x");
-  writeFileSync(join(v, ".obsidian", "cfg.md"), "x");
-  writeFileSync(join(v, "top.md"), "x");
+test('walks .md recursively, excludes _archive/_archived/Excalidraw and dotdirs', () => {
+  const v = join(tmpdir(), `ll-vault-${randomBytes(8).toString('hex')}`);
+  mkdirSync(join(v, '3-permanent'), { recursive: true });
+  mkdirSync(join(v, '_archive'), { recursive: true });
+  mkdirSync(join(v, 'Excalidraw'), { recursive: true });
+  mkdirSync(join(v, '.obsidian'), { recursive: true });
+  writeFileSync(join(v, '3-permanent', 'a.md'), 'x');
+  writeFileSync(join(v, '_archive', 'old.md'), 'x');
+  writeFileSync(join(v, 'Excalidraw', 'd.excalidraw.md'), 'x');
+  writeFileSync(join(v, '.obsidian', 'cfg.md'), 'x');
+  writeFileSync(join(v, 'top.md'), 'x');
 
-  const rel = listVaultNotes(v).map((n) => n.path.slice(v.length + 1)).sort();
+  const rel = listVaultNotes(v)
+    .map((n) => n.path.slice(v.length + 1).replace(/\\/g, '/'))
+    .sort();
   rmSync(v, { recursive: true, force: true });
-  assert.deepEqual(rel, ["3-permanent/a.md", "top.md"]);
+  assert.deepEqual(rel, ['3-permanent/a.md', 'top.md']);
 });


### PR DESCRIPTION
Triages the known-red `windows-latest` lane (114 failures, continue-on-error) to green.

Four win32-portability root causes — all test-side except the encoder, which had a real latent bug:

1. **`.pathname` for file paths** (22 files) — `new URL(rel, import.meta.url).pathname` yields `/D:/a/...` on Windows; `node /D:/...` and `runHook` fail → empty stdout. Now `fileURLToPath()`.
2. **ESM import scheme** — spawned `import("D:\\...")` throws `ERR_UNSUPPORTED_ESM_URL_SCHEME`. Import the `file://` href instead.
3. **Hardcoded `/tmp` + `/` separators** — `hook-stop-nudge` transcript fixtures (`D:\tmp` ENOENT) → `tmpdir()`; `paths-data-files` expected strings → derived with `join()`.
4. **Project-dir slug encoder** — `replace(/[/\\]/g,'-')` left the drive colon (`C:-Users-x`, illegal Windows dir → mkdir ENOENT) and never replaced `.` (wrong memory dir for dotfile-parented projects even on POSIX). Claude Code replaces `/ \ . :` with `-` (verified against real `~/.claude/projects` entries). Centralised as `encodeProjectDir()` in `paths.mjs`; all 6 production + 4 test sites route through it.

Full Node suite green locally (1007/1007). This PR exists to verify the **windows-latest** lane. Once green, a follow-up flips `continue-on-error` off (test.yml:20) to make Windows blocking.

Note: includes prior unpushed commit `c7da64a` (null-guard `isVaultNote`) as a base.