### PR TITLE
fix: make health-check probes Windows-aware (.exe, .cmd, exec-bit, PATHEXT)

### DIFF
--- a/plugin/scripts/health-check.mjs
+++ b/plugin/scripts/health-check.mjs
@@ -31,6 +31,9 @@ function safeExec(cmd, args, opts = {}) {
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'ignore'],
       timeout: 3000,
+      // Windows: execFileSync does not honor PATHEXT, so bare 'claude'/'node'
+      // miss their .cmd shims and read as "not found". Route through cmd.exe.
+      shell: process.platform === 'win32',
       ...opts,
     }).trim();
   } catch {
@@ -110,7 +113,8 @@ export async function runFullChecks(ctx = {}) {
     return data?.plugins || data || {};
   })();
 
-  const binaryPath = c.pluginData ? join(c.pluginData, 'bin', 'll-search') : null;
+  const binaryName = process.platform === 'win32' ? 'll-search.exe' : 'll-search';
+  const binaryPath = c.pluginData ? join(c.pluginData, 'bin', binaryName) : null;
   let binaryVersionOutput = null;
   let binaryExitCode = 127;
   if (binaryPath && existsSync(binaryPath)) {

--- a/plugin/scripts/lib/health-checks/quick.mjs
+++ b/plugin/scripts/lib/health-checks/quick.mjs
@@ -155,7 +155,11 @@ export function checkBinaryExists({ pluginData } = {}) {
       fix: 'Run /learning-loop:init to download the binary',
     });
   }
-  const binPath = join(pluginData, 'bin', 'll-search');
+  const binPath = join(
+    pluginData,
+    'bin',
+    process.platform === 'win32' ? 'll-search.exe' : 'll-search',
+  );
   if (!existsSync(binPath)) {
     return makeCheck({
       id: CHECK_IDS['binary-exists'],
@@ -168,7 +172,7 @@ export function checkBinaryExists({ pluginData } = {}) {
   }
   try {
     const stat = statSync(binPath);
-    if (!(stat.mode & 0o111)) {
+    if (process.platform !== 'win32' && !(stat.mode & 0o111)) {
       return makeCheck({
         id: CHECK_IDS['binary-exists'],
         name: 'll-search binary',
@@ -271,13 +275,17 @@ export function checkShimsExist({ home } = {}) {
       fix: 'Set $HOME',
     });
   }
+  const isWin = process.platform === 'win32';
+  const shimExt = isWin ? '.cmd' : '';
   const missing = [];
   for (const s of ['ll-watch', 'll-search']) {
-    const p = join(home, '.local/bin', s);
+    const p = join(home, '.local/bin', s + shimExt);
     if (!existsSync(p)) {
       missing.push(s);
       continue;
     }
+    // Windows .cmd shims carry no POSIX exec bit; existence is sufficient.
+    if (isWin) continue;
     try {
       const stat = statSync(p);
       if (!(stat.mode & 0o111)) missing.push(`${s} (not executable)`);

--- a/tests/health-check.test.mjs
+++ b/tests/health-check.test.mjs
@@ -288,6 +288,60 @@ test(
   },
 );
 
+// Windows checks: the native binary is `ll-search.exe` and the shims are
+// `.cmd`, and Node statSync reports no POSIX exec bit for either. These mock
+// process.platform so the win32 branches run on the (POSIX) CI runner too.
+test('checkBinaryExists: ok on win32 when ll-search.exe present (no POSIX exec bit)', () => {
+  const original = Object.getOwnPropertyDescriptor(process, 'platform');
+  Object.defineProperty(process, 'platform', { value: 'win32' });
+  try {
+    const dir = mkdtempSync(join(tmpdir(), 'health-bin-win-'));
+    mkdirSync(join(dir, 'bin'));
+    writeFileSync(join(dir, 'bin/ll-search.exe'), 'MZ');
+    const result = checkBinaryExists({ pluginData: dir });
+    assert.equal(result.status, 'ok');
+    assert.match(result.detail, /ll-search\.exe$/);
+    rmSync(dir, { recursive: true, force: true });
+  } finally {
+    Object.defineProperty(process, 'platform', original);
+  }
+});
+
+test('checkShimsExist: ok on win32 when .cmd shims present (no POSIX exec bit)', () => {
+  const original = Object.getOwnPropertyDescriptor(process, 'platform');
+  Object.defineProperty(process, 'platform', { value: 'win32' });
+  try {
+    const home = mkdtempSync(join(tmpdir(), 'health-shims-win-'));
+    mkdirSync(join(home, '.local/bin'), { recursive: true });
+    for (const s of ['ll-watch.cmd', 'll-search.cmd']) {
+      writeFileSync(join(home, '.local/bin', s), '@echo off\n');
+    }
+    const result = checkShimsExist({ home });
+    assert.equal(result.status, 'ok');
+    rmSync(home, { recursive: true, force: true });
+  } finally {
+    Object.defineProperty(process, 'platform', original);
+  }
+});
+
+test('checkShimsExist: fail on win32 when only extensionless shims exist', () => {
+  const original = Object.getOwnPropertyDescriptor(process, 'platform');
+  Object.defineProperty(process, 'platform', { value: 'win32' });
+  try {
+    const home = mkdtempSync(join(tmpdir(), 'health-shims-win-noext-'));
+    mkdirSync(join(home, '.local/bin'), { recursive: true });
+    for (const s of ['ll-watch', 'll-search']) {
+      writeFileSync(join(home, '.local/bin', s), '#!/usr/bin/env bash\n');
+    }
+    const result = checkShimsExist({ home });
+    assert.equal(result.status, 'fail');
+    assert.match(result.detail, /ll-watch/);
+    rmSync(home, { recursive: true, force: true });
+  } finally {
+    Object.defineProperty(process, 'platform', original);
+  }
+});
+
 test('checkLocalBinOnPath: ok when ~/.local/bin in PATH', () => {
   const result = checkLocalBinOnPath({
     home: '/home/test',


### PR DESCRIPTION
Fixes #3.

## Problem

On Windows, `/learning-loop:doctor` reports four hard failures even when the binary, shims, and Claude Code are all installed and working. All four are false positives in the health-check probes (POSIX assumptions), not real install problems. The runtime path is unaffected: `lib/binary.mjs` already resolves `ll-search.exe`, so semantic search and indexing work while the checker reports the binary missing.

Verified before the fix that `bin/ll-search.exe version` returns `1.33.0`, `vault-search.mjs search` returns ranked results, the `.cmd` shims exist, and `claude --version` works in the shell, while doctor still showed `binary-exists`, `binary-runs`, `shims-exist`, and `claude-version` as FAIL.

## Changes

1. **`.exe` on the binary path** (`health-check.mjs`, `quick.mjs` `checkBinaryExists`): the binary is `ll-search.exe` on Windows. Drives `binary-exists` and `binary-runs`.
2. **`.cmd` on the shim path** (`quick.mjs` `checkShimsExist`): `install-shims.mjs` writes `ll-watch.cmd` / `ll-search.cmd`. Drives `shims-exist`.
3. **Skip the POSIX exec-bit test on win32** (binary + shims): `stat.mode & 0o111` is always 0 for `.exe`/`.cmd` under Node `statSync`, so existence is the correct signal there.
4. **`shell: true` on win32 in `safeExec`**: `execFileSync` does not honor PATHEXT, so bare `claude`/`node` miss their `.cmd` shims and read as "not found". Drives `claude-version` (and the misleading Linux `install.sh` fix it suggested).

All win32 behavior is guarded behind `process.platform === 'win32'`, so POSIX behavior is byte-for-byte unchanged.

## Tests

Added three `win32`-mocked cases to `tests/health-check.test.mjs` (mock `process.platform` so the branches run on the POSIX CI runner): `.exe` binary OK, `.cmd` shims OK, and extensionless-only shims FAIL on win32. The existing `skipOnWindows` exec-bit tests are untouched.

## Local checks

- `npx prettier --check` on changed files: clean.
- `npx eslint .`: 0 errors (only pre-existing unused-disable warnings, including one on `main`).
- `node --test tests/health-check.test.mjs`: 87 pass, 0 fail (3 `skipOnWindows`, 3 new win32 cases pass).

Result on a real Windows box: doctor goes from `19 pass / 1 warn / 4 fail` to `23 pass / 1 warn / 0 fail` (remaining warn is the legitimate `local-bin-on-path`).

## Possibly related (not addressed here)

The session-start hook injects `PLUGIN_DATA=...\data\learning-loop-inline`, but `resolve-paths.mjs` / `download-binary.mjs` resolve `...\data\learning-loop-learning-loop-marketplace`. Both `bin/` dirs end up populated, so it is not breaking, but `download-binary.mjs` reporting "already installed" in one root while the checker probes the other is confusing. Flagging in case it points at a path-derivation inconsistency; happy to look if you want it in scope.
