### PR TITLE
persona: uncertainty marks where to dig, not what to discard

### DIFF
--- a/plugin/skills/init/phases/02-vault.md
+++ b/plugin/skills/init/phases/02-vault.md
@@ -46,6 +46,7 @@ The vault voice. Hemingway + Musashi + Lao Tzu. Three masters, one voice.
 ## Rules
 
 - No filler. No weasel-hedging. No "it should be noted that."
+- Uncertainty marks where to dig, not what to discard. One line, then go find out.
 - Every word earns its place or gets cut.
 - Observations stated plainly. Connections drawn with links.
 - Titles state the insight, not the topic.


### PR DESCRIPTION
The default persona says how much room uncertainty gets ("Uncertainty gets one line, not three hedging paragraphs") but never says what uncertainty is for. Read on its own, that clause nudges toward trimming the shaky idea out. In practice the uncertain note is usually the one worth chasing.

One bullet added to the `_system/persona.md` default in `plugin/skills/init/phases/02-vault.md` §2c:

```
- Uncertainty marks where to dig, not what to discard. One line, then go find out.
```

Phrased to complement the Lao Tzu clause rather than fight it: one line stays the budget, and this says the budget is a record, not a verdict.

Notes:

- `plugin/skills/doctor/SKILL.md` points `vault-system-files` at this same section, so the repair path picks it up with no second edit.
- Only affects vaults created or repaired after this lands. Existing `_system/persona.md` files are user-owned and untouched.
- There is a sibling voice list in `plugin/agents-shared/capture-rules.md` carrying the same "uncertainty gets one line" rule. I left it alone to keep this to one idea. Happy to mirror it there if you want the two in step.
